### PR TITLE
chore: add plugin `autorefs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "scipy>=1.10.1;python_version=='3.11'",
     "scipy>=1.11.3;python_version=='3.12'",
     "scipy>=1.15.0;python_version=='3.13'",
-    "scipy>=1.16.1;python_version=='3.14'"
+    "scipy>=1.16.1;python_version=='3.14'",
+    "mkdocs-autorefs>=1.4.4",
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 
@@ -78,5 +79,5 @@ dev = [
 ]
 docs = [
     "mkdocstrings-python>=2.0.3",
-    "zensical>=0.0.41"
+    "zensical>=0.0.41",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ dependencies = [
     "scipy>=1.10.1;python_version=='3.11'",
     "scipy>=1.11.3;python_version=='3.12'",
     "scipy>=1.15.0;python_version=='3.13'",
-    "scipy>=1.16.1;python_version=='3.14'",
-    "mkdocs-autorefs>=1.4.4",
+    "scipy>=1.16.1;python_version=='3.14'"
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 
@@ -78,6 +77,7 @@ dev = [
     "ruff>=0.15.12"
 ]
 docs = [
+    "mkdocs-autorefs>=1.4.4",
     "mkdocstrings-python>=2.0.3",
-    "zensical>=0.0.41",
+    "zensical>=0.0.41"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -659,6 +659,7 @@ name = "pystatpower"
 version = "0.0.5"
 source = { editable = "." }
 dependencies = [
+    { name = "mkdocs-autorefs" },
     { name = "scipy", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
 ]
@@ -677,6 +678,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mkdocs-autorefs", specifier = ">=1.4.4" },
     { name = "scipy", marker = "python_full_version == '3.10.*'", specifier = ">=1.7.2,<1.16" },
     { name = "scipy", marker = "python_full_version == '3.11.*'", specifier = ">=1.10.1" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.11.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,6 @@ name = "pystatpower"
 version = "0.0.5"
 source = { editable = "." }
 dependencies = [
-    { name = "mkdocs-autorefs" },
     { name = "scipy", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
 ]
@@ -672,13 +671,13 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mkdocs-autorefs" },
     { name = "mkdocstrings-python" },
     { name = "zensical" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "mkdocs-autorefs", specifier = ">=1.4.4" },
     { name = "scipy", marker = "python_full_version == '3.10.*'", specifier = ">=1.7.2,<1.16" },
     { name = "scipy", marker = "python_full_version == '3.11.*'", specifier = ">=1.10.1" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.11.3" },
@@ -694,6 +693,7 @@ dev = [
     { name = "ruff", specifier = ">=0.15.12" },
 ]
 docs = [
+    { name = "mkdocs-autorefs", specifier = ">=1.4.4" },
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },
     { name = "zensical", specifier = ">=0.0.41" },
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -159,3 +159,8 @@ members_order = "source"
 attributes = false
 functions = true
 modules = false
+
+[project.plugins.autorefs]
+
+[project.validation]
+unresolved_references = false


### PR DESCRIPTION
Add the `mkdocs-autorefs` plugin to make it easier to reference the API in the documentation.