### PR TITLE
build: update license config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ keywords = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ build-backend = "setuptools.build_meta"
 name = "pystatpower"
 version = "0.0.6"
 description = "A Power Analysis Toolkit for Python"
-license = { text = "GPL-3.0" }
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [
     { name = "Snoopy1866", email = "pystatpower@gmail.com" }


### PR DESCRIPTION
As per [PEP 639](https://peps.python.org/pep-0639/), use `project.license` and `project.license-files` config, and remove license classifier.