### PR TITLE
chore(codecov): enable carryforward flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,8 @@ github_checks:
 
 comment:
   layout: "diff, flags, files"
+  show_carryforward_flags: true
+
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
This PR enables codecov [carryforward flags](https://docs.codecov.com/docs/carryforward-flags)