### PR TITLE
refactor: use `pytest_generate_tests` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,11 @@ repos:
       - id: forbid-submodules
       - id: name-tests-test
         args: [--pytest-test-first]
-        exclude: ^tests/smoke_test\.py$
+        exclude: |
+          (?x)^(
+              tests/smoke_test\.py|
+              tests/models\.py
+          )$
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+from dataclasses import asdict
+
+from .models import BaseTestCase
+
+
+def generate_id(case: BaseTestCase) -> str:
+    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
+    return ", ".join(parts)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """
+    This is a custom pytest hook which is called when collecting a test function, it can automatically finds `case_group` and inject parameters.
+
+    Reference: https://docs.pytest.org/en/stable/how-to/parametrize.html#basic-pytest-generate-tests-example
+    """
+
+    if "case" in metafunc.fixturenames:
+        case_group = getattr(metafunc.module, "case_group", None)
+        if case_group is not None:
+            metafunc.parametrize("case", case_group, ids=generate_id)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BaseTestCase:
+    __test__ = False
+
+    ...

--- a/tests/test_correlation/test_ci.py
+++ b/tests/test_correlation/test_ci.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
@@ -6,11 +6,11 @@ import pytest
 from pystatpower.correlation.ci import solve_distance, solve_size, solve_correlation
 from pystatpower.exceptions import SolutionNotFoundError
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     correlation: float
     size: int
     conf_level: float
@@ -181,14 +181,9 @@ case_group_bias_adj = (
 case_group = case_group_not_bias_adj + case_group_bias_adj
 
 
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
+# @pytest.fixture(params=case_group, ids=generate_id)
+# def case(request: pytest.FixtureRequest) -> TestCase:
+#     return request.param
 
 
 def test_solve_distance(case: TestCase) -> None:

--- a/tests/test_correlation/test_inequality.py
+++ b/tests/test_correlation/test_inequality.py
@@ -1,15 +1,15 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
 from pystatpower.correlation.inequality import solve_correlation, solve_null_correlation, solve_power, solve_size
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_correlation: float
     correlation: float
     alternative: Literal["two-sided", "lower one-sided", "upper one-sided"]
@@ -94,16 +94,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_mean/test_independent/test_ci.py
+++ b/tests/test_mean/test_independent/test_ci.py
@@ -1,16 +1,16 @@
 # Validation Software: PASS 15
 # Module: Confidence Intervals for the Difference Between Two Means
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_std: float
     reference_std: float
     treatment_size: int
@@ -95,16 +95,6 @@ case_group_unequal_var = [
 ]
 
 case_group = case_group_equal_var + case_group_unequal_var
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_distance(case: TestCase) -> None:

--- a/tests/test_mean/test_independent/test_inequality.py
+++ b/tests/test_mean/test_independent/test_inequality.py
@@ -5,18 +5,18 @@
 #         Two-Sample T-Tests Assuming Unequal Variance
 # Two-Sample T-Test Assuming Unequal Variance with Degree of Freedom Adjusted by Welch's Methos is not available in PASS.
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
 from pystatpower.mean.independent.inequality import solve_power, solve_size, solve_diff, solve_treatment_mean, solve_reference_mean, solve_treatment_std, solve_reference_std
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_mean: float | None
     reference_mean: float | None
     diff: float | None
@@ -660,16 +660,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_mean/test_independent/test_noninferiority.py
+++ b/tests/test_mean/test_independent/test_noninferiority.py
@@ -1,18 +1,18 @@
 # Validation Software: PASS 15
 # Module: Non-Inferiority Tests for the Difference Between Two Means
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
 from pystatpower.mean.independent.noninferiority import solve_power, solve_size, solve_diff, solve_margin, solve_treatment_std, solve_reference_std
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_mean: float
     reference_mean: float
     margin: float
@@ -274,16 +274,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_mean/test_independent/test_superiority.py
+++ b/tests/test_mean/test_independent/test_superiority.py
@@ -1,18 +1,18 @@
 # Validation Software: PASS 15
 # Module: Superiority by a Margin Tests for the Difference Between Two Means
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
 from pystatpower.mean.independent.superiority import solve_power, solve_size, solve_diff, solve_margin, solve_treatment_std, solve_reference_std
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_mean: float
     reference_mean: float
     margin: float
@@ -345,16 +345,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_mean/test_single/test_ci.py
+++ b/tests/test_mean/test_single/test_ci.py
@@ -1,18 +1,16 @@
 # Validation Software: PASS 15
 # Module: Confidence Intervals for One Mean
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
-
-import pytest
 
 from pystatpower.mean.single.ci import solve_half_width, solve_size, solve_std
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     target_half_width: float
     actual_half_width: float
     std: float
@@ -88,16 +86,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_half_width(case: TestCase) -> None:

--- a/tests/test_mean/test_single/test_inequality.py
+++ b/tests/test_mean/test_single/test_inequality.py
@@ -1,18 +1,18 @@
 # Validation Software: PASS 15
 # Module: Tests for One Mean
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
 from pystatpower.mean.single.inequality import solve_power, solve_size, solve_null_mean, solve_mean
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_mean: float
     mean: float
     std: float
@@ -128,16 +128,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_mean/test_single/test_noninferiority.py
+++ b/tests/test_mean/test_single/test_noninferiority.py
@@ -1,7 +1,7 @@
 # Validation Software: PASS 15
 # Module: Non-Inferiority Tests for One Mean
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
@@ -9,11 +9,11 @@ import sys
 
 from pystatpower.mean.single.noninferiority import solve_power, solve_size, solve_diff, solve_null_mean, solve_mean, solve_std, solve_margin
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_mean: float | None
     mean: float | None
     diff: float | None
@@ -77,16 +77,6 @@ case_group = [
         (10.0, 15, 0.821309977),
     ]
 ]
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_mean/test_single/test_superiority.py
+++ b/tests/test_mean/test_single/test_superiority.py
@@ -1,7 +1,7 @@
 # Validation Software: PASS 15
 # Module: Superiority by a Margin Tests for One Mean (One-Sample or Paired T-Test)
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
@@ -9,11 +9,11 @@ import sys
 
 from pystatpower.mean.single.superiority import solve_power, solve_size, solve_diff, solve_null_mean, solve_mean, solve_std, solve_margin
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_mean: float | None
     mean: float | None
     diff: float | None
@@ -79,16 +79,6 @@ case_group = [
         (0.0, 16, 0.800555580),
     ]
 ]
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_independent/test_ci.py
+++ b/tests/test_proportion/test_independent/test_ci.py
@@ -1,18 +1,16 @@
 # Validation Software: PASS 15
 # Module: Confidence Intervals for the Difference Between Two Proportions
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
-
-import pytest
 
 from pystatpower.proportion.independent.ci import solve_distance, solve_size, solve_treatment_proportion, solve_reference_proportion
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_proportion: float
     reference_proportion: float
     treatment_size: int
@@ -747,16 +745,6 @@ case_group_miettinen_nurminen = (
 
 
 case_group = case_group_chisq + case_group_chisq_cc + case_group_newcombe_wilson + case_group_newcombe_wilson_cc + case_group_farrington_manning + case_group_miettinen_nurminen
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_distance(case: TestCase) -> None:

--- a/tests/test_proportion/test_independent/test_inequality.py
+++ b/tests/test_proportion/test_independent/test_inequality.py
@@ -1,18 +1,16 @@
 # Validation Software: PASS 15
 # Module: Tests for Two Proportions
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
-
-import pytest
 
 from pystatpower.proportion.independent.inequality import solve_power, solve_size, solve_treatment_proportion, solve_reference_proportion
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_proportion: float
     reference_proportion: float
     treatment_size: int
@@ -315,16 +313,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_independent/test_noninferiority.py
+++ b/tests/test_proportion/test_independent/test_noninferiority.py
@@ -1,17 +1,15 @@
 # Validation Software: PASS 15
 # Module: Non-Inferiority Tests for the Difference Between Two Proportions
 
-from dataclasses import dataclass, asdict
-
-import pytest
+from dataclasses import dataclass
 
 from pystatpower.proportion.independent.noninferiority import solve_margin, solve_power, solve_reference_proportion, solve_size, solve_treatment_proportion
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_proportion: float
     reference_proportion: float
     margin: float
@@ -282,16 +280,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_independent/test_superiority.py
+++ b/tests/test_proportion/test_independent/test_superiority.py
@@ -1,17 +1,15 @@
 # Validation Software: PASS 15
 # Module: Superiority by a Margin for the Difference Between Two Proportions
 
-from dataclasses import dataclass, asdict
-
-import pytest
+from dataclasses import dataclass
 
 from pystatpower.proportion.independent.superiority import solve_power, solve_size, solve_treatment_proportion, solve_reference_proportion, solve_margin
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     treatment_proportion: float
     reference_proportion: float
     margin: float
@@ -318,16 +316,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_single/test_ci.py
+++ b/tests/test_proportion/test_single/test_ci.py
@@ -1,18 +1,18 @@
 # Validation Software: PASS 15
 # Module: Confidence Interval for One Proportion
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
 
 import pytest
 
 from pystatpower.proportion.single.ci import solve_distance, solve_proportion, solve_size
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     proportion: float
     size: int
     distance: float
@@ -281,16 +281,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_solve_size(case: TestCase) -> None:

--- a/tests/test_proportion/test_single/test_equivalence.py
+++ b/tests/test_proportion/test_single/test_equivalence.py
@@ -1,17 +1,15 @@
 # Validation Software: PASS 15
 # Module: Equivalence Tests for One Proportion
 
-from dataclasses import dataclass, asdict
-
-import pytest
+from dataclasses import dataclass
 
 from pystatpower.proportion.single.equivalence import solve_power, solve_size, solve_null_proportion, solve_proportion
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_proportion: float
     proportion: float
     margin_lower: float
@@ -126,16 +124,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_single/test_inequality.py
+++ b/tests/test_proportion/test_single/test_inequality.py
@@ -1,18 +1,16 @@
 # Validation Software: PASS 15
 # Module: Tests for One Proportions
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
-
-import pytest
 
 from pystatpower.proportion.single.inequality import solve_power, solve_size, solve_null_proportion, solve_proportion
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_proportion: float
     proportion: float
     size: int
@@ -320,16 +318,6 @@ case_group = (
         TestCase(null_proportion=0.98, proportion=0.90, size=43, alternative="two-sided", alpha=0.05, power=0.80, phat=False, continuity_correction=False, actual_power=0.8017),
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_single/test_noninferiority.py
+++ b/tests/test_proportion/test_single/test_noninferiority.py
@@ -1,18 +1,16 @@
 # Validation Software: PASS 15
 # Module: Non-Inferiority Tests for One Proportion
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
-
-import pytest
 
 from pystatpower.proportion.single.noninferiority import solve_power, solve_size, solve_null_proportion, solve_proportion, solve_margin
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_proportion: float
     proportion: float
     margin: float
@@ -203,16 +201,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_power(case: TestCase) -> None:

--- a/tests/test_proportion/test_single/test_superiority.py
+++ b/tests/test_proportion/test_single/test_superiority.py
@@ -1,18 +1,16 @@
 # Validation Software: PASS 15
 # Module: Non-Inferiority Tests for One Proportion
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Literal
-
-import pytest
 
 from pystatpower.proportion.single.superiority import solve_power, solve_size, solve_null_proportion, solve_proportion, solve_margin
 
+from tests.models import BaseTestCase
+
 
 @dataclass
-class TestCase:
-    __test__ = False
-
+class TestCase(BaseTestCase):
     null_proportion: float
     proportion: float
     margin: float
@@ -216,16 +214,6 @@ case_group = (
         ]
     ]
 )
-
-
-def get_id(case: TestCase) -> str:
-    parts = [f"{k}={v}" for k, v in asdict(case).items() if v is not None]
-    return ", ".join(parts)
-
-
-@pytest.fixture(params=case_group, ids=get_id)
-def case(request: pytest.FixtureRequest) -> TestCase:
-    return request.param
 
 
 def test_size_solve_power(case: TestCase) -> None:


### PR DESCRIPTION
### **User description**
Use `pytest_generate_tests `hook.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Use `pytest_generate_tests` hook to inject test cases from module-level `case_group`

- Introduce shared `BaseTestCase` dataclass to mark test case classes

- Remove duplicated `get_id` functions and manual fixtures across all test modules

- Clean up redundant imports (e.g., `asdict`, `pytest`) in affected files


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["module case_group"] -- "read by" --> B["pytest_generate_tests in conftest.py"]
    B -- "parametrize `case`" --> C["case fixture"]
    C --> D["test functions"]
    E["BaseTestCase in models.py"] -- "inherited by" --> F["TestCase classes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>conftest.py</strong><dd><code>Add `generate_id` helper and `pytest_generate_tests` hook</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Introduce shared `BaseTestCase` dataclass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-969c0712020e8472d8d78ae32190692cc1e8a3e16dc17f6977c8f87a1328adb7">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>test_ci.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-7a192a27ef0ff78d4966a5cbd10cc8df3a78c08886e165c91e8a4661c9cf696f">+7/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inequality.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-d432b6756877bade8412d60a8f8ef1009737dc4247c4f377639b9f12de26e5a4">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ci.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-c47ea4fee57c1b926a3ca99791c75017fd5ccc493d0d89a0422f0be32d479148">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inequality.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-e8783d8c3ac2cc8a167db5cbc51915150a3ebb630d86cf445fc68b706bb90c34">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_noninferiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-6abd5e288ff67dc2e66fea263b37b06184a3840a4af3ab00f3eeb4d5e8da4f9b">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_superiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-c7f16c1716107659f3b80fd48cfa8173125ccf6ac0eb2c2d4c9455e3d2fca210">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ci.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-fc23b65a4de1479ad7823ffd3effe1e4cef5364837dba83eb1e518dbda31e3c1">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inequality.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-93de78dd8b5486f5b5a25a49b96179d6beaa6c21521b08344846515d0cb561a6">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_noninferiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-6a2ebd3416b8ac5b6cf2d719cd060a330045d5e6cf64b7387848153bbbae8814">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_superiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-691545b8f2f5b895519a1d3408f9de1dbf4c32809850f296ad41b1f0aa95454e">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ci.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-077620338f705a92e012b9ef8f45f3e40edd45879a29ec320205f7fd924541ec">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inequality.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-b0dfdaefe82dc7cc85f9dfe6910cb10bf4b155dfe45d813f275c5a7367a6e145">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_noninferiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-8aec48fc3893f80f9f40755f65baecee44b2e5388342143b6503a67255dd71df">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_superiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-cac8e6b729398897cb2a20e9f4af827379c8393ed274814af01403f90a6c50ab">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ci.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-65b7ff0406b8576a38d942dfc218abafde8b6aaac2e1d184862746b62aff87a4">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_equivalence.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-6796089203ff51c6fcd6388bc87e46a0b63952af1461bbce02fe24c94c929a6c">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inequality.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-e22248ba93c6b78b5a70f96af2bb56c5a0a84893d490ebedef67c1d5faa1afdb">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_noninferiority.py</strong><dd><code>Inherit from `BaseTestCase`, remove `get_id` and fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-28bee4cc9f2b9d3a715e0402b34dde5d830bcc7581953e9691db6cbae9e84229">+4/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84d">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_superiority.py</strong></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/421/files#diff-0232f3f69836009e98818352c6cfdf3a6ae23ff4a4afd1a28cbfbff5a883d61e">+4/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

