### PR TITLE
refactor: unify the signature of `alternative` and `interval_type`

### DIFF
--- a/src/pystatpower/correlation/ci.py
+++ b/src/pystatpower/correlation/ci.py
@@ -8,7 +8,10 @@ from ..exceptions import SolutionNotFoundError
 
 
 def _distance_not_adjusted(
-    correlation: float, size: float, conf_level: float, interval_type: Literal["two-sided", "upper", "lower"]
+    correlation: float,
+    size: float,
+    conf_level: float,
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound"""
 
@@ -20,20 +23,23 @@ def _distance_not_adjusted(
             L = zr - norm.ppf(1 - alpha / 2) / sqrt(size - 3)
             U = zr + norm.ppf(1 - alpha / 2) / sqrt(size - 3)
             distance = tanh(U) - tanh(L)
-        case "upper":
-            # L = -1
-            U = zr + norm.ppf(1 - alpha) / sqrt(size - 3)
-            distance = tanh(U) - correlation
         case "lower":
             L = zr - norm.ppf(1 - alpha) / sqrt(size - 3)
             # U = 1
             distance = correlation - tanh(L)
+        case "upper":
+            # L = -1
+            U = zr + norm.ppf(1 - alpha) / sqrt(size - 3)
+            distance = tanh(U) - correlation
 
     return float(distance)
 
 
 def _distance_adjusted(
-    correlation: float, size: float, conf_level: float, interval_type: Literal["two-sided", "upper", "lower"]
+    correlation: float,
+    size: float,
+    conf_level: float,
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound, adjusted for bias."""
 
@@ -46,14 +52,14 @@ def _distance_adjusted(
             L = zr - bias - norm.ppf(1 - alpha / 2) / sqrt(size - 3)
             U = zr - bias + norm.ppf(1 - alpha / 2) / sqrt(size - 3)
             distance = tanh(U) - tanh(L)
-        case "upper":
-            # L = -1
-            U = zr - bias + norm.ppf(1 - alpha) / sqrt(size - 3)
-            distance = tanh(U) - correlation
         case "lower":
             L = zr - bias - norm.ppf(1 - alpha) / sqrt(size - 3)
             # U = 1
             distance = correlation - tanh(L)
+        case "upper":
+            # L = -1
+            U = zr - bias + norm.ppf(1 - alpha) / sqrt(size - 3)
+            distance = tanh(U) - correlation
 
     return float(distance)
 
@@ -62,7 +68,7 @@ def _distance(
     correlation: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "upper", "lower"],
+    interval_type: Literal["two-sided", "lower", "upper"],
     bias_adj: bool,
 ) -> float:
     """Calculate the correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound"""
@@ -78,7 +84,7 @@ def solve_distance(
     correlation: float,
     size: int,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "upper", "lower"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     bias_adj: bool = False,
 ) -> float:
     """Calculate the correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound
@@ -90,12 +96,12 @@ def solve_distance(
             Sample size $n$.
         conf_level (float, optional):
             Condidence level.
-        interval_type (Literal["two-sided", "upper", "lower"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'upper'`: Upper one-sided confidence interval.
             - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         bias_adj (bool, optional):
             Whether to adjust for bias.
 
@@ -111,7 +117,7 @@ def solve_size(
     correlation: float,
     distance: float,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "upper", "lower"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     bias_adj: bool = False,
 ) -> int:
     """Estimate the required sample size, given the correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound
@@ -122,17 +128,17 @@ def solve_size(
         distance (float):
             Correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound.
 
-            - If `interval_type = 'two-sided'`, specify the correlation coefficient two-sided confidence interval width.
-            - If `interval_type = 'upper'`, specify the distance from the correlation coefficient to the upper one-sided confidence bound.
-            - If `interval_type = 'lower'`, specify the distance from the correlation coefficient to the lower one-sided confidence bound.
+            - If `interval_type` = `'two-sided'`, specify the correlation coefficient two-sided confidence interval width.
+            - If `interval_type` = `'lower'`, specify the distance from the correlation coefficient to the lower one-sided confidence bound.
+            - If `interval_type` = `'upper'`, specify the distance from the correlation coefficient to the upper one-sided confidence bound.
         conf_level (float, optional):
             Condidence level.
-        interval_type (Literal["two-sided", "upper", "lower"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'upper'`: Upper one-sided confidence interval.
             - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         bias_adj (bool, optional):
             Whether to adjust for bias.
 
@@ -158,7 +164,7 @@ def solve_correlation(
     distance: float,
     size: int,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "upper", "lower"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     bias_adj: bool = False,
 ) -> float | tuple[float, float]:
     """Estimate the required correlation coefficient, given the correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound
@@ -167,19 +173,19 @@ def solve_correlation(
         distance (float):
             Correlation coefficient confidence interval width or the distance from the correlation coefficient to the confidence bound.
 
-            - If `interval_type = 'two-sided'`, specify the correlation coefficient two-sided confidence interval width.
-            - If `interval_type = 'upper'`, specify the distance from the correlation coefficient to the upper one-sided confidence bound.
-            - If `interval_type = 'lower'`, specify the distance from the correlation coefficient to the lower one-sided confidence bound.
+            - If `interval_type` = `'two-sided'`, specify the correlation coefficient two-sided confidence interval width.
+            - If `interval_type` = `'lower'`, specify the distance from the correlation coefficient to the lower one-sided confidence bound.
+            - If `interval_type` = `'upper'`, specify the distance from the correlation coefficient to the upper one-sided confidence bound.
         size (int):
             Sample size $n$.
         conf_level (float, optional):
             Condidence level.
-        interval_type (Literal["two-sided", "upper", "lower"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'upper'`: Upper one-sided confidence interval.
             - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         bias_adj (bool, optional):
             Whether to adjust for bias.
 

--- a/src/pystatpower/correlation/inequality.py
+++ b/src/pystatpower/correlation/inequality.py
@@ -10,7 +10,7 @@ from .._constant import SAMPLE_SIZE_SEARCH_MAX
 def _power_not_adjusted(
     null_correlation: float,
     correlation: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     size: float,
     alpha: float,
 ) -> float:
@@ -26,10 +26,10 @@ def _power_not_adjusted(
                 - norm.cdf(norm.ppf(1 - alpha / 2) - (zeta - null_zeta) * sqrt(size - 3))
                 + norm.cdf(norm.ppf(alpha / 2) - (zeta - null_zeta) * sqrt(size - 3))
             )
-        case "lower one-sided":
-            power = norm.cdf(norm.ppf(alpha) - (zeta - null_zeta) * sqrt(size - 3))
-        case "upper one-sided":
+        case "greater":
             power = 1 - norm.cdf(norm.ppf(1 - alpha) - (zeta - null_zeta) * sqrt(size - 3))
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (zeta - null_zeta) * sqrt(size - 3))
 
     return float(power)
 
@@ -37,7 +37,7 @@ def _power_not_adjusted(
 def _power_adjusted(
     null_correlation: float,
     correlation: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     size: float,
     alpha: float,
 ) -> float:
@@ -58,14 +58,14 @@ def _power_adjusted(
                     - (zeta - null_zeta + 1 / 2 * (correlation - null_correlation) / (size - 1)) * sqrt(size - 3)
                 )
             )
-        case "lower one-sided":
-            power = norm.cdf(
-                norm.ppf(alpha)
-                - (zeta - null_zeta + 1 / 2 * (correlation - null_correlation) / (size - 1)) * sqrt(size - 3)
-            )
-        case "upper one-sided":
+        case "greater":
             power = 1 - norm.cdf(
                 norm.ppf(1 - alpha)
+                - (zeta - null_zeta + 1 / 2 * (correlation - null_correlation) / (size - 1)) * sqrt(size - 3)
+            )
+        case "less":
+            power = norm.cdf(
+                norm.ppf(alpha)
                 - (zeta - null_zeta + 1 / 2 * (correlation - null_correlation) / (size - 1)) * sqrt(size - 3)
             )
 
@@ -75,7 +75,7 @@ def _power_adjusted(
 def _power(
     null_correlation: float,
     correlation: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     size: float,
     alpha: float,
     bias_adj: bool,
@@ -93,7 +93,7 @@ def solve_power(
     null_correlation: float,
     correlation: float,
     size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     bias_adj: bool = False,
 ) -> float:
@@ -106,17 +106,17 @@ def solve_power(
             Correlation coefficient under the alternative hypothesis.
         size (int):
             Sample size.
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\rho_1 \\neq \\rho_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         bias_adj (bool, optional):
             Specify whether the bias adjustment is used or not.
 
@@ -133,7 +133,7 @@ def solve_size(
     *,
     null_correlation: float,
     correlation: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     power: float = 0.80,
     bias_adj: bool = False,
@@ -145,17 +145,17 @@ def solve_size(
             Correlation coefficient under the null hypothesis.
         correlation (float):
             Correlation coefficient under the alternative hypothesis.
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\rho_1 \\neq \\rho_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Power of the test.
         bias_adj (bool, optional):
@@ -177,7 +177,7 @@ def solve_correlation(
     *,
     null_correlation: float,
     size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     power: float = 0.80,
     bias_adj: bool = False,
@@ -191,17 +191,17 @@ def solve_correlation(
             Correlation coefficient under the null hypothesis.
         size (int):
             Sample size.
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\rho_1 \\neq \\rho_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Power of the test.
         bias_adj (bool, optional):
@@ -231,7 +231,7 @@ def solve_null_correlation(
     *,
     correlation: float,
     size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     power: float = 0.80,
     bias_adj: bool = False,
@@ -245,17 +245,17 @@ def solve_null_correlation(
             Correlation coefficient under the alternative hypothesis.
         size (int):
             Sample size.
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\rho_1 \\neq \\rho_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\rho_1 > \\rho_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\rho_1 < \\rho_0$
         alpha (float, optional):
             Two-sided significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'less'` or `'greater'`, provide the one-sided significance level.
         power (float, optional):
             Power of the test.
         bias_adj (bool, optional):

--- a/src/pystatpower/mean/independent/inequality.py
+++ b/src/pystatpower/mean/independent/inequality.py
@@ -12,7 +12,7 @@ def _power_z_equal_var(
     std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for an inequality test of two independent means using z-test with equal variance."""
@@ -21,10 +21,10 @@ def _power_z_equal_var(
     match alternative:
         case "two-sided":
             power = 1 - norm.cdf(norm.ppf(1 - alpha / 2) - (diff) / se) + norm.cdf(norm.ppf(alpha / 2) - (diff) / se)
-        case "lower one-sided":
-            power = norm.cdf(norm.ppf(alpha) - (diff) / se)
-        case "upper one-sided":
+        case "greater":
             power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff) / se)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (diff) / se)
 
     return float(power)
 
@@ -35,7 +35,7 @@ def _power_z_unequal_var(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for an inequality test of two independent means using z-test with unequal variance."""
@@ -44,10 +44,10 @@ def _power_z_unequal_var(
     match alternative:
         case "two-sided":
             power = 1 - norm.cdf(norm.ppf(1 - alpha / 2) - (diff) / se) + norm.cdf(norm.ppf(alpha / 2) - (diff) / se)
-        case "lower one-sided":
-            power = norm.cdf(norm.ppf(alpha) - (diff) / se)
-        case "upper one-sided":
+        case "greater":
             power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff) / se)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (diff) / se)
 
     return float(power)
 
@@ -58,7 +58,7 @@ def _power_t_equal_var(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for an inequality test of two independent means using t-test with equal variance."""
@@ -70,10 +70,10 @@ def _power_t_equal_var(
     match alternative:
         case "two-sided":
             power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
-        case "lower one-sided":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper one-sided":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return float(power)
 
@@ -84,7 +84,7 @@ def _power_unequal_var_satterthwaite(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """
@@ -101,10 +101,10 @@ def _power_unequal_var_satterthwaite(
     match alternative:
         case "two-sided":
             power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
-        case "lower one-sided":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper one-sided":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return float(power)
 
@@ -115,7 +115,7 @@ def _power_unequal_var_welch(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """
@@ -132,10 +132,10 @@ def _power_unequal_var_welch(
     match alternative:
         case "two-sided":
             power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
-        case "lower one-sided":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper one-sided":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return float(power)
 
@@ -149,7 +149,7 @@ def _power(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
     method: Literal["z", "t"],
     equal_var: bool,
@@ -203,7 +203,7 @@ def solve_power(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     method: Literal["z", "t"] = "t",
     equal_var: bool = False,
@@ -233,17 +233,17 @@ def solve_power(
             Sample size in the treatment group ($n_1$).
         reference_size (int):
             Sample size in the reference group ($n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
 
         method (Literal["z", "t"], optional):
             The distribution used for the test.
@@ -300,7 +300,7 @@ def solve_size(
     treatment_std: float,
     reference_std: float,
     ratio: float = 1,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -329,17 +329,17 @@ def solve_size(
             Standard deviation in the reference group ($\\sigma_2$).
         ratio (float, optional):
             Ratio of treatment sample size to reference sample size ($k = n_1 / n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -432,7 +432,7 @@ def solve_diff(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     search_direction: Literal["above", "below"] = "above",
     alpha: float = 0.05,
     power: float = 0.80,
@@ -452,12 +452,12 @@ def solve_diff(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
         search_direction (Literal["above", "below"], optional):
             Specify whether to search for the mean difference above or below 0.
 
@@ -467,7 +467,7 @@ def solve_diff(
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -534,7 +534,7 @@ def solve_treatment_mean(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     search_direction: Literal["above", "below"] = "above",
     alpha: float = 0.05,
     power: float = 0.80,
@@ -556,12 +556,12 @@ def solve_treatment_mean(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
         search_direction (Literal["above", "below"], optional):
             Specify whether to search for the treatment mean above or below the reference mean.
 
@@ -571,7 +571,7 @@ def solve_treatment_mean(
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -638,7 +638,7 @@ def solve_reference_mean(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     search_direction: Literal["above", "below"] = "below",
     alpha: float = 0.05,
     power: float = 0.80,
@@ -660,12 +660,12 @@ def solve_reference_mean(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
         search_direction (Literal["above", "below"], optional):
             Specify whether to search for the reference mean above or below the treatment mean.
 
@@ -675,7 +675,7 @@ def solve_reference_mean(
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -742,7 +742,7 @@ def solve_treatment_std(
     diff: float | None = None,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -770,17 +770,17 @@ def solve_treatment_std(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -872,7 +872,7 @@ def solve_reference_std(
     diff: float | None = None,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
     alpha: float = 0.05,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -900,17 +900,17 @@ def solve_reference_std(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"], optional):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_2$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_2$
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_2$
         alpha (float, optional):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):

--- a/src/pystatpower/mean/independent/superiority.py
+++ b/src/pystatpower/mean/independent/superiority.py
@@ -13,17 +13,17 @@ def _power_z_equal_var(
     std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a superiority test of two independent means using z-test with equal variance."""
 
     se = std * sqrt(1 / treatment_size + 1 / reference_size)
     match alternative:
-        case "lower":
-            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
     return float(power)
 
 
@@ -34,17 +34,17 @@ def _power_z_unequal_var(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a superiority test of two independent means using z-test with unequal variance."""
 
     se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
     match alternative:
-        case "lower":
-            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
     return float(power)
 
 
@@ -55,7 +55,7 @@ def _power_t_equal_var(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a superiority test of two independent means using t-test with equal variance."""
@@ -65,10 +65,10 @@ def _power_t_equal_var(
     nc = (diff - margin) / sqrt(var_c * (1 / treatment_size + 1 / reference_size))
 
     match alternative:
-        case "lower":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return power
 
@@ -80,7 +80,7 @@ def _power_unequal_var_welch(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """
@@ -95,10 +95,10 @@ def _power_unequal_var_welch(
     nc = (diff - margin) / sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
 
     match alternative:
-        case "lower":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return power
 
@@ -110,7 +110,7 @@ def _power_unequal_var_satterthwaite(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """
@@ -125,10 +125,10 @@ def _power_unequal_var_satterthwaite(
     nc = (diff - margin) / sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
 
     match alternative:
-        case "lower":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return power
 
@@ -143,7 +143,7 @@ def _power(
     reference_std: float,
     treatment_size: float,
     reference_size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
     method: Literal["z", "t"],
     equal_var: bool,
@@ -209,7 +209,7 @@ def solve_power(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     method: Literal["z", "t"] = "t",
     equal_var: bool = False,
@@ -244,11 +244,11 @@ def solve_power(
             Sample size in the treatment group ($n_1$).
         reference_size (int):
             Sample size in the reference group ($n_2$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis.
 
-            - `'lower'`: lower-tailed alternative hypothesis: $\\mu_1 - \\mu_2 < \\delta$
-            - `'upper'`: upper-tailed alternative hypothesis: $\\mu_1 - \\mu_2 > \\delta$
+            - `'greater'`: upper-tailed alternative hypothesis: $\\mu_1 - \\mu_2 > \\delta$
+            - `'less'`: lower-tailed alternative hypothesis: $\\mu_1 - \\mu_2 < \\delta$
         alpha (float, optional):
             One-sided significance level.
         method (Literal["z", "t"], optional):
@@ -311,7 +311,7 @@ def solve_size(
     treatment_std: float,
     reference_std: float,
     ratio: float = 1,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -345,11 +345,11 @@ def solve_size(
             Standard deviation in the reference group ($\\sigma_2$).
         ratio (float, optional):
             Ratio of treatment sample size to reference sample size ($k = n_1 / n_2$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis.
 
-            - `'lower'`: lower-tailed alternative hypothesis: $\\mu_1 - \\mu_2 < \\delta$
-            - `'upper'`: upper-tailed alternative hypothesis: $\\mu_1 - \\mu_2 > \\delta$
+            - `'greater'`: upper-tailed alternative hypothesis: $\\mu_1 - \\mu_2 > \\delta$
+            - `'less'`: lower-tailed alternative hypothesis: $\\mu_1 - \\mu_2 < \\delta$
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -450,7 +450,7 @@ def solve_diff(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -474,11 +474,11 @@ def solve_diff(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis.
 
-            - `'lower'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-            - `'upper'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -548,9 +548,9 @@ def solve_diff(
     DIFF_SEARCH_MAX = 1000000
 
     match alternative:
-        case "lower":
+        case "less":
             return float(brentq(func, DIFF_SEARCH_MIN, margin))
-        case "upper":
+        case "greater":
             return float(brentq(func, margin, DIFF_SEARCH_MAX))
 
 
@@ -561,7 +561,7 @@ def solve_margin(
     reference_std: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -582,11 +582,11 @@ def solve_margin(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis.
 
-            - `'lower'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-            - `'upper'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -653,10 +653,10 @@ def solve_margin(
         )
 
     match alternative:
-        case "lower":
-            return brentq(func, diff, 0.000001)
-        case "upper":
+        case "greater":
             return brentq(func, -0.000001, diff)
+        case "less":
+            return brentq(func, diff, 0.000001)
 
 
 def solve_treatment_std(
@@ -667,7 +667,7 @@ def solve_treatment_std(
     margin: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -700,11 +700,11 @@ def solve_treatment_std(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis.
 
-            - `'lower'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-            - `'upper'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
+            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -802,7 +802,7 @@ def solve_reference_std(
     margin: float,
     treatment_size: int,
     reference_size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
     method: Literal["z", "t"] = "t",
@@ -835,11 +835,11 @@ def solve_reference_std(
             Sample size for the treatment group ($n_1$).
         reference_size (int):
             Sample size for the reference group ($n_2$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis.
 
-            - `'lower'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-            - `'upper'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
+            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):

--- a/src/pystatpower/mean/single/inequality.py
+++ b/src/pystatpower/mean/single/inequality.py
@@ -12,7 +12,7 @@ def _power_z(
     mean: float,
     std: float,
     size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for an inequality test of one mean using z-test."""
@@ -24,10 +24,10 @@ def _power_z(
                 - norm.cdf(norm.ppf(1 - alpha / 2) - sqrt(size) * (mean - null_mean) / std)
                 + norm.cdf(norm.ppf(alpha / 2) - sqrt(size) * (mean - null_mean) / std)
             )
-        case "lower one-sided":
-            power = norm.cdf(norm.ppf(alpha) - sqrt(size) * (mean - null_mean) / std)
-        case "upper one-sided":
+        case "greater":
             power = 1 - norm.cdf(norm.ppf(1 - alpha) - sqrt(size) * (mean - null_mean) / std)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - sqrt(size) * (mean - null_mean) / std)
 
     return float(power)
 
@@ -37,7 +37,7 @@ def _power_t(
     mean: float,
     std: float,
     size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for an inequality test of one mean using t-test."""
@@ -48,10 +48,10 @@ def _power_t(
     match alternative:
         case "two-sided":
             power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
-        case "lower one-sided":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-        case "upper one-sided":
+        case "greater":
             power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
 
     return float(power)
 
@@ -61,7 +61,7 @@ def _power(
     mean: float,
     std: float,
     size: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
     method: Literal["z", "t"],
 ) -> float:
@@ -82,7 +82,7 @@ def solve_power(
     mean: float,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
     method: Literal["z", "t"],
 ) -> float:
@@ -100,17 +100,17 @@ def solve_power(
             - If `method='t'`, provide the sample standard deviation ($S$).
         size (int):
             Sample size ($n$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"]):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
-        alpha (float, optional):
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
+        alpha (float):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         method (Literal["z", "t"], optional):
             The distribution used for the test.
 
@@ -130,7 +130,7 @@ def solve_size(
     null_mean: float,
     mean: float,
     std: float,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
     power: float,
     method: Literal["z", "t"],
@@ -147,17 +147,17 @@ def solve_size(
             Standard deviation ($\\sigma$).
 
             - If `method='t'`, provide the sample standard deviation ($S$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"]):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
-        alpha (float, optional):
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
+        alpha (float):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -182,7 +182,7 @@ def solve_null_mean(
     mean: float,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
     power: float,
     method: Literal["z", "t"],
@@ -200,17 +200,17 @@ def solve_null_mean(
             - If `method='t'`, provide the sample standard deviation ($S$).
         size (int):
             Sample size ($n$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"]):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
-        alpha (float, optional):
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
+        alpha (float):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):
@@ -246,7 +246,7 @@ def solve_mean(
     null_mean: float,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    alternative: Literal["two-sided", "greater", "less"],
     alpha: float,
     power: float,
     method: Literal["z", "t"],
@@ -264,17 +264,17 @@ def solve_mean(
             - If `method='t'`, provide the sample standard deviation ($S$).
         size (int):
             Sample size ($n$).
-        alternative (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        alternative (Literal["two-sided", "greater", "less"]):
             Type of the alternative hypothesis.
 
             - `'two-sided'`: Two-sided alternative hypothesis: $\\mu_1 \\neq \\mu_0$
-            - `'lower one-sided'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
-            - `'upper one-sided'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
-        alpha (float, optional):
+            - `'greater'`: Upper one-sided alternative hypothesis: $\\mu_1 > \\mu_0$
+            - `'less'`: Lower one-sided alternative hypothesis: $\\mu_1 < \\mu_0$
+        alpha (float):
             Significance level.
 
             - If `alternative` is `'two-sided'`, provide the two-sided significance level.
-            - If `alternative` is `'lower one-sided'` or `'upper one-sided'`, provide the one-sided significance level.
+            - If `alternative` is `'greater'` or `'less'`, provide the one-sided significance level.
         power (float, optional):
             Desired statistical power.
         method (Literal["z", "t"], optional):

--- a/src/pystatpower/proportion/independent/ci.py
+++ b/src/pystatpower/proportion/independent/ci.py
@@ -11,7 +11,7 @@ def _distance_chisq(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """
     Calculate the confidence interval width or the distance from the proportion difference to the confidence bound
@@ -31,11 +31,11 @@ def _distance_chisq(
             L = diff - z * sd
             U = diff + z * sd
             distance = min(U, 1) - max(L, -1)
-        case "lower one-sided":
+        case "lower":
             z = norm.ppf(1 - alpha)
             L = diff - z * sd
             distance = diff - max(L, -1)
-        case "upper one-sided":
+        case "upper":
             z = norm.ppf(1 - alpha)
             U = diff + z * sd
             distance = min(U, 1) - diff
@@ -49,7 +49,7 @@ def _distance_chisq_cc(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """
     Calculate the confidence interval width or the distance from the proportion difference to the confidence bound
@@ -70,11 +70,11 @@ def _distance_chisq_cc(
             L = diff - z * sd - c
             U = diff + z * sd + c
             distance = min(U, 1) - max(L, -1)
-        case "lower one-sided":
+        case "lower":
             z = norm.ppf(1 - alpha)
             L = diff - z * sd - c
             distance = diff - max(L, -1)
-        case "upper one-sided":
+        case "upper":
             z = norm.ppf(1 - alpha)
             U = diff + z * sd + c
             distance = min(U, 1) - diff
@@ -88,7 +88,7 @@ def _distance_newcombe_wilson(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """
     Calculate the confidence interval width or the distance from the proportion difference to the confidence bound
@@ -128,7 +128,7 @@ def _distance_newcombe_wilson(
                 + sqrt((U_1 - treatment_proportion) ** 2 + (reference_proportion - L_2) ** 2)
             )
             distance = U - L
-        case "lower one-sided":
+        case "lower":
             z = norm.ppf(1 - alpha)
 
             # calculate the wilson interval of the treatment proportion
@@ -153,7 +153,7 @@ def _distance_newcombe_wilson(
             )
             # U = 1
             distance = diff - L
-        case "upper one-sided":
+        case "upper":
             z = norm.ppf(1 - alpha)
 
             # calculate the wilson interval of the treatment proportion
@@ -188,7 +188,7 @@ def _distance_newcombe_wilson_cc(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """
     Calculate the confidence interval width or the distance from the proportion difference to the confidence bound
@@ -232,7 +232,7 @@ def _distance_newcombe_wilson_cc(
                 + sqrt((U_1 - treatment_proportion) ** 2 + (reference_proportion - L_2) ** 2)
             )
             distance = U - L
-        case "lower one-sided":
+        case "lower":
             z = norm.ppf(1 - alpha)
 
             # calculate the wilson interval of the treatment proportion
@@ -261,7 +261,7 @@ def _distance_newcombe_wilson_cc(
             )
             # U = 1
             distance = diff - L
-        case "upper one-sided":
+        case "upper":
             z = norm.ppf(1 - alpha)
 
             # calculate the wilson interval of the treatment proportion
@@ -300,7 +300,7 @@ def _distance_farrington_manning(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """
     Calculate the confidence interval width or the distance from the proportion difference to the confidence bound
@@ -342,11 +342,11 @@ def _distance_farrington_manning(
             L = brentq(lambda delta: func(delta) - norm.ppf(1 - alpha / 2), -1 + eps, diff)
             U = brentq(lambda delta: func(delta) - norm.ppf(alpha / 2), diff, 1 - eps)
             distance = U - L
-        case "lower one-sided":
+        case "lower":
             # z = norm.ppf(1 - alpha)
             L = brentq(lambda delta: func(delta) - norm.ppf(1 - alpha), -1 + eps, diff)
             distance = diff - L
-        case "upper one-sided":
+        case "upper":
             # z = norm.ppf(1 - alpha)
             U = brentq(lambda delta: func(delta) - norm.ppf(alpha), diff, 1 - eps)
             distance = U - diff
@@ -360,7 +360,7 @@ def _distance_miettinen_nurminen(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """
     Calculate the confidence interval width or the distance from the proportion difference to the confidence bound
@@ -402,11 +402,11 @@ def _distance_miettinen_nurminen(
             L = brentq(lambda delta: func(delta) - norm.ppf(1 - alpha / 2), -1 + eps, diff)
             U = brentq(lambda delta: func(delta) - norm.ppf(alpha / 2), diff, 1 - eps)
             distance = U - L
-        case "lower one-sided":
+        case "lower":
             # z = norm.ppf(1 - alpha)
             L = brentq(lambda delta: func(delta) - norm.ppf(1 - alpha), -1 + eps, diff)
             distance = diff - L
-        case "upper one-sided":
+        case "upper":
             # z = norm.ppf(1 - alpha)
             U = brentq(lambda delta: func(delta) - norm.ppf(alpha), diff, 1 - eps)
             distance = U - diff
@@ -420,7 +420,7 @@ def _distance(
     treatment_size: float,
     reference_size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
     method: Literal[
         "chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"
     ],
@@ -466,7 +466,7 @@ def solve_distance(
     treatment_size: int,
     reference_size: int,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal[
         "chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"
     ] = "chisq",
@@ -485,12 +485,12 @@ def solve_distance(
             Sample size in the reference group ($n_2$). Must be greater than 0.
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'lower one-sided'`: Lower one-sided confidence interval.
-            - `'upper one-sided'`: Upper one-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         method (Literal["chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"], optional):
             Method to calculate the confidence interval.
 
@@ -520,7 +520,7 @@ def solve_size(
     distance: float,
     ratio: float = 1,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal[
         "chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"
     ] = "chisq",
@@ -536,19 +536,19 @@ def solve_size(
         distance (float):
             Confidence interval width or the distance from the proportion difference to the confidence bound.
 
-            - If `interval_type='two-sided'`, provide confidence interval width.
-            - If `interval_type='lower one-sided'`, provide the distance from the proportion difference to the lower one-side confidence bound.
-            - If `interval_type='upper one-sided'`, provide the distance from the proportion difference to the upper one-side confidence bound.
+            - If `interval_type` = `'two-sided'`, provide confidence interval width.
+            - If `interval_type` = `'lower'`, provide the distance from the proportion difference to the lower one-side confidence bound.
+            - If `interval_type` = `'upper'`, provide the distance from the proportion difference to the upper one-side confidence bound.
         ratio (float, optional):
             Ratio of the sample size in the treatment group to the sample size in the reference group ($k = n_1 / n_2$).
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'lower one-sided'`: Lower one-sided confidence interval.
-            - `'upper one-sided'`: Upper one-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         method (Literal["chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"], optional):
             Method to calculate the confidence interval.
 
@@ -611,7 +611,7 @@ def solve_treatment_proportion(
     reference_size: int,
     distance: float,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal[
         "chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"
     ] = "chisq",
@@ -629,17 +629,17 @@ def solve_treatment_proportion(
         distance (float):
             Confidence interval width or the distance from the proportion difference to the confidence bound.
 
-            - If `interval_type='two-sided'`, provide confidence interval width.
-            - If `interval_type='lower one-sided'`, provide the distance from the proportion difference to the lower one-side confidence bound.
-            - If `interval_type='upper one-sided'`, provide the distance from the proportion difference to the upper one-side confidence bound.
+            - If `interval_type` = `'two-sided'`, provide confidence interval width.
+            - If `interval_type` = `'lower'`, provide the distance from the proportion difference to the lower one-side confidence bound.
+            - If `interval_type` = `'upper'`, provide the distance from the proportion difference to the upper one-side confidence bound.
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'lower one-sided'`: Lower one-sided confidence interval.
-            - `'upper one-sided'`: Upper one-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         method (Literal["chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"], optional):
             Method to calculate the confidence interval.
 
@@ -692,7 +692,7 @@ def solve_reference_proportion(
     reference_size: int,
     distance: float,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal[
         "chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"
     ] = "chisq",
@@ -710,17 +710,17 @@ def solve_reference_proportion(
         distance (float):
             Confidence interval width or the distance from the proportion difference to the confidence bound.
 
-            - If `interval_type='two-sided'`, provide confidence interval width.
-            - If `interval_type='lower one-sided'`, provide the distance from the proportion difference to the lower one-side confidence bound.
-            - If `interval_type='upper one-sided'`, provide the distance from the proportion difference to the upper one-side confidence bound.
+            - If `interval_type` = `'two-sided'`, provide confidence interval width.
+            - If `interval_type` = `'lower'`, provide the distance from the proportion difference to the lower one-side confidence bound.
+            - If `interval_type` = `'upper'`, provide the distance from the proportion difference to the upper one-side confidence bound.
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `'two-sided'`: Two-sided confidence interval.
-            - `'lower one-sided'`: Lower one-sided confidence interval.
-            - `'upper one-sided'`: Upper one-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         method (Literal["chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"], optional):
             Method to calculate the confidence interval.
 

--- a/src/pystatpower/proportion/single/ci.py
+++ b/src/pystatpower/proportion/single/ci.py
@@ -11,7 +11,7 @@ def _distance_wald(
     proportion: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wald method."""
 
@@ -20,10 +20,10 @@ def _distance_wald(
             lower_limit = proportion - norm.ppf((1 + conf_level) / 2) * sqrt(proportion * (1 - proportion) / size)
             upper_limit = proportion + norm.ppf((1 + conf_level) / 2) * sqrt(proportion * (1 - proportion) / size)
             distance = min(upper_limit, 1) - max(lower_limit, 0)
-        case "lower one-sided":
+        case "lower":
             lower_limit = proportion - norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size)
             distance = proportion - max(lower_limit, 0)
-        case "upper one-sided":
+        case "upper":
             upper_limit = proportion + norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size)
             distance = min(upper_limit, 1) - proportion
 
@@ -34,7 +34,7 @@ def _distance_wald_cc(
     proportion: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wald method with continuity correction."""
 
@@ -51,12 +51,12 @@ def _distance_wald_cc(
                 + 1 / (2 * size)
             )
             distance = min(upper_limit, 1) - max(lower_limit, 0)
-        case "lower one-sided":
+        case "lower":
             lower_limit = (
                 proportion - norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size) - 1 / (2 * size)
             )
             distance = proportion - max(lower_limit, 0)
-        case "upper one-sided":
+        case "upper":
             upper_limit = (
                 proportion + norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size) + 1 / (2 * size)
             )
@@ -69,7 +69,7 @@ def _distance_wilson(
     proportion: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wilson method."""
 
@@ -86,13 +86,13 @@ def _distance_wilson(
                 * sqrt(norm.ppf((1 + conf_level) / 2) ** 2 + 4 * size * proportion * (1 - proportion))
             ) / (2 * (size + norm.ppf((1 + conf_level) / 2) ** 2))
             distance = upper_limit - lower_limit
-        case "lower one-sided":
+        case "lower":
             lower_limit = (
                 (2 * size * proportion + norm.ppf(conf_level) ** 2)
                 - norm.ppf(conf_level) * sqrt(norm.ppf(conf_level) ** 2 + 4 * size * proportion * (1 - proportion))
             ) / (2 * (size + norm.ppf(conf_level) ** 2))
             distance = proportion - lower_limit
-        case "upper one-sided":
+        case "upper":
             upper_limit = (
                 (2 * size * proportion + norm.ppf(conf_level) ** 2)
                 + norm.ppf(conf_level) * sqrt(norm.ppf(conf_level) ** 2 + 4 * size * proportion * (1 - proportion))
@@ -106,7 +106,7 @@ def _distance_wilson_cc(
     proportion: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wilson method, with continuity correction."""
 
@@ -136,7 +136,7 @@ def _distance_wilson_cc(
                 )
             ) / (2 * (size + norm.ppf((1 + conf_level) / 2) ** 2))
             distance = upper_limit - lower_limit
-        case "lower one-sided":
+        case "lower":
             lower_limit = (
                 (2 * size * proportion + norm.ppf(conf_level) ** 2 - 1)
                 - norm.ppf(conf_level)
@@ -145,7 +145,7 @@ def _distance_wilson_cc(
                 )
             ) / (2 * (size + norm.ppf(conf_level) ** 2))
             distance = proportion - lower_limit
-        case "upper one-sided":
+        case "upper":
             upper_limit = (
                 (2 * size * proportion + norm.ppf(conf_level) ** 2 + 1)
                 + norm.ppf(conf_level)
@@ -162,7 +162,7 @@ def _distance_clopper_pearson(
     proportion: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
     """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Clopper-Pearson method."""
 
@@ -187,14 +187,14 @@ def _distance_clopper_pearson(
                 )
             )
             distance = upper_limit - lower_limit
-        case "lower one-sided":
+        case "lower":
             lower_limit = 1 / (
                 1
                 + (size * (1 - proportion) + 1)
                 / (size * proportion * f.ppf(1 - conf_level, 2 * size * proportion, 2 * (size * (1 - proportion) + 1)))
             )
             distance = proportion - lower_limit
-        case "upper one-sided":
+        case "upper":
             upper_limit = 1 / (
                 1
                 + size
@@ -213,7 +213,7 @@ def _distance(
     proportion: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"],
+    interval_type: Literal["two-sided", "lower", "upper"],
     method: Literal["clopper-pearson", "wald", "wilson"],
     continuity_correction: bool = False,
 ) -> float:
@@ -239,7 +239,7 @@ def solve_distance(
     proportion: float,
     size: int,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal["clopper-pearson", "wald", "wilson"] = "clopper-pearson",
     continuity_correction: bool = False,
 ) -> float:
@@ -253,12 +253,12 @@ def solve_distance(
             Sample size.
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `two-sided`: Two-sided confidence interval $(L, U)$.
-            - `lower one-sided`: Lower one-sided confidence interval $(L, +\\infty)$.
-            - `upper one-sided`: Upper one-sided confidence interval $(-\\infty, U)$.
+            - `lower`: Lower one-sided confidence interval $(L, +\\infty)$.
+            - `upper`: Upper one-sided confidence interval $(-\\infty, U)$.
         method (Literal["clopper-pearson", "wald", "wilson"], optional):
             Method used in calculation of the confidence interval.
         continuity_correction (bool, optional):
@@ -279,7 +279,7 @@ def solve_size(
     proportion: float,
     distance: float,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal["clopper-pearson", "wald", "wilson"] = "clopper-pearson",
     continuity_correction: bool = False,
 ) -> int:
@@ -290,16 +290,16 @@ def solve_size(
         proportion (float):
             Proportion.
         distance (float):
-            - if `interval_type='two-sided'`, provide confidence interval width.
-            - if `interval_type='lower one-sided'` or `interval_type='upper one-sided'`, provide the distance from the proportion to the confidence bound.
+            - if `interval_type` = `'two-sided'`, provide confidence interval width.
+            - if `interval_type` = `'lower'` or `interval_type` = `'upper'`, provide the distance from the proportion to the confidence bound.
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `two-sided`: Two-sided confidence interval $(L, U)$.
-            - `lower one-sided`: Lower one-sided confidence interval $(L, +\\infty)$.
-            - `upper one-sided`: Upper one-sided confidence interval $(-\\infty, U)$.
+            - `lower`: Lower one-sided confidence interval $(L, +\\infty)$.
+            - `upper`: Upper one-sided confidence interval $(-\\infty, U)$.
         method (Literal["clopper-pearson", "wald", "wilson"], optional):
             Method used in calculation of the confidence interval.
         continuity_correction (bool | None, optional):
@@ -336,9 +336,9 @@ def solve_size(
         match interval_type:
             case "two-sided":
                 lower_bound = max(n1, n2, n3, n4)
-            case "lower one-sided":
+            case "lower":
                 lower_bound = max(n3, n4)
-            case "upper one-sided":
+            case "upper":
                 lower_bound = max(n1, n2)
 
         upper_bound = SAMPLE_SIZE_SEARCH_MAX
@@ -363,7 +363,7 @@ def solve_proportion(
     size: int,
     distance: float,
     conf_level: float = 0.95,
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"] = "two-sided",
+    interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
     method: Literal["clopper-pearson", "wald", "wilson"] = "clopper-pearson",
     continuity_correction: bool = False,
     search_direction: Literal["below", "above"] = "above",
@@ -374,16 +374,16 @@ def solve_proportion(
         size (int):
             Sample size.
         distance (float):
-            - if `interval_type='two-sided'`, provide confidence interval width.
-            - if `interval_type='lower one-sided'` or `interval_type='upper one-sided'`, provide the distance from the proportion to the confidence bound.
+            - if `interval_type` = `'two-sided'`, provide confidence interval width.
+            - if `interval_type` = `'lower'` or `interval_type` = `'upper'`, provide the distance from the proportion to the confidence bound.
         conf_level (float, optional):
             Confidence level.
-        interval_type (Literal["two-sided", "lower one-sided", "upper one-sided"], optional):
+        interval_type (Literal["two-sided", "lower", "upper"], optional):
             Type of the confidence interval.
 
             - `two-sided`: Two-sided confidence interval $(L, U)$.
-            - `lower one-sided`: Lower one-sided confidence interval $(L, +\\infty)$.
-            - `upper one-sided`: Upper one-sided confidence interval $(-\\infty, U)$.
+            - `lower`: Lower one-sided confidence interval $(L, +\\infty)$.
+            - `upper`: Upper one-sided confidence interval $(-\\infty, U)$.
         method (Literal["clopper-pearson", "wald", "wilson"], optional):
             Method used in calculation of the confidence interval.
         continuity_correction (bool | None, optional):

--- a/src/pystatpower/proportion/single/noninferiority.py
+++ b/src/pystatpower/proportion/single/noninferiority.py
@@ -12,7 +12,7 @@ def _power_p0(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion non-inferiority test, using $p_0$ to calculate variance."""
@@ -20,19 +20,19 @@ def _power_p0(
     proportion_noninf = null_proportion + margin
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
-                    + (proportion - proportion_noninf) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 (
                     norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
                     - (proportion - proportion_noninf) * sqrt(size)
+                )
+                / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                (
+                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
+                    + (proportion - proportion_noninf) * sqrt(size)
                 )
                 / sqrt(proportion * (1 - proportion))
             )
@@ -45,7 +45,7 @@ def _power_p0_cc(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion non-inferiority test with continuity correction, using $p_0$ to calculate variance."""
@@ -60,19 +60,19 @@ def _power_p0_cc(
         c = 1 / (2 * size)
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
-                    + (proportion - proportion_noninf + c) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 (
                     norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
                     - (proportion - proportion_noninf + c) * sqrt(size)
+                )
+                / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                (
+                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
+                    + (proportion - proportion_noninf + c) * sqrt(size)
                 )
                 / sqrt(proportion * (1 - proportion))
             )
@@ -85,7 +85,7 @@ def _power_phat(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion non-inferiority test, using $\\hat{p}$ to calculate variance."""
@@ -93,15 +93,15 @@ def _power_phat(
     proportion_noninf = null_proportion + margin
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                + (proportion - proportion_noninf) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 norm.ppf(1 - alpha)
                 - (proportion - proportion_noninf) * sqrt(size) / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                norm.ppf(1 - alpha)
+                + (proportion - proportion_noninf) * sqrt(size) / sqrt(proportion * (1 - proportion))
             )
 
     return float(power)
@@ -112,7 +112,7 @@ def _power_phat_cc(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion non-inferiority test with continuity correction, using $\\hat{p}$ to calculate variance."""
@@ -127,15 +127,15 @@ def _power_phat_cc(
         c = 1 / (2 * size)
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                + (proportion - proportion_noninf + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 norm.ppf(1 - alpha)
                 - (proportion - proportion_noninf + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                norm.ppf(1 - alpha)
+                + (proportion - proportion_noninf + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
             )
 
     return float(power)
@@ -146,7 +146,7 @@ def _power(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
     phat: bool,
     continuity_correction: bool,
@@ -172,7 +172,7 @@ def solve_power(
     proportion: float,
     margin: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     phat: bool = True,
     continuity_correction: bool = False,
@@ -189,11 +189,11 @@ def solve_power(
             Non-inferiority margin ($\\delta$).
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         phat (bool, optional):
@@ -213,7 +213,7 @@ def solve_size(
     null_proportion: float,
     proportion: float,
     margin: float,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -229,11 +229,11 @@ def solve_size(
             Proportion under the alternative hypothesis ($p$).
         margin (float):
             Non-inferiority margin ($\\delta$).
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -260,7 +260,7 @@ def solve_null_proportion(
     proportion: float,
     margin: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -276,11 +276,11 @@ def solve_null_proportion(
             Non-inferiority margin ($\\delta$).
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -323,7 +323,7 @@ def solve_proportion(
     null_proportion: float,
     margin: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -339,11 +339,11 @@ def solve_proportion(
             Non-inferiority margin ($\\delta$).
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -386,7 +386,7 @@ def solve_margin(
     null_proportion: float,
     proportion: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -402,11 +402,11 @@ def solve_margin(
             Proportion under the alternative hypothesis ($p$).
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -437,9 +437,9 @@ def solve_margin(
         )
 
     match alternative:
-        case "lower":
-            margin = brentq(func, max(proportion - null_proportion, 0), 1 - null_proportion)
-        case "upper":
+        case "greater":
             margin = brentq(func, -null_proportion, min(proportion - null_proportion, 0))
+        case "less":
+            margin = brentq(func, max(proportion - null_proportion, 0), 1 - null_proportion)
 
     return float(margin)

--- a/src/pystatpower/proportion/single/superiority.py
+++ b/src/pystatpower/proportion/single/superiority.py
@@ -12,7 +12,7 @@ def _power_p0(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion superiority test, using $p_0$ to calculate variance."""
@@ -20,19 +20,19 @@ def _power_p0(
     proportion_sup = null_proportion + margin
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_sup * (1 - proportion_sup))
-                    + (proportion - proportion_sup) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 (
                     norm.ppf(1 - alpha) * sqrt(proportion_sup * (1 - proportion_sup))
                     - (proportion - proportion_sup) * sqrt(size)
+                )
+                / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                (
+                    norm.ppf(1 - alpha) * sqrt(proportion_sup * (1 - proportion_sup))
+                    + (proportion - proportion_sup) * sqrt(size)
                 )
                 / sqrt(proportion * (1 - proportion))
             )
@@ -45,7 +45,7 @@ def _power_p0_cc(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion superiority test with continuity correction, using $p_0$ to calculate variance."""
@@ -60,19 +60,19 @@ def _power_p0_cc(
         c = 1 / (2 * size)
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_sup * (1 - proportion_sup))
-                    + (proportion - proportion_sup + c) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 (
                     norm.ppf(1 - alpha) * sqrt(proportion_sup * (1 - proportion_sup))
                     - (proportion - proportion_sup + c) * sqrt(size)
+                )
+                / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                (
+                    norm.ppf(1 - alpha) * sqrt(proportion_sup * (1 - proportion_sup))
+                    + (proportion - proportion_sup + c) * sqrt(size)
                 )
                 / sqrt(proportion * (1 - proportion))
             )
@@ -85,7 +85,7 @@ def _power_phat(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion superiority test, using $\\hat{p}$ to calculate variance."""
@@ -93,13 +93,13 @@ def _power_phat(
     proportion_sup = null_proportion + margin
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha) + (proportion - proportion_sup) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 norm.ppf(1 - alpha) - (proportion - proportion_sup) * sqrt(size) / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                norm.ppf(1 - alpha) + (proportion - proportion_sup) * sqrt(size) / sqrt(proportion * (1 - proportion))
             )
 
     return float(power)
@@ -110,7 +110,7 @@ def _power_phat_cc(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
 ) -> float:
     """Calculate the statistical power for a one-sample proportion superiority test with continuity correction, using $\\hat{p}$ to calculate variance."""
@@ -125,15 +125,15 @@ def _power_phat_cc(
         c = 1 / (2 * size)
 
     match alternative:
-        case "lower":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                + (proportion - proportion_sup + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-        case "upper":
+        case "greater":
             power = 1 - norm.cdf(
                 norm.ppf(1 - alpha)
                 - (proportion - proportion_sup + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
+            )
+        case "less":
+            power = 1 - norm.cdf(
+                norm.ppf(1 - alpha)
+                + (proportion - proportion_sup + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
             )
 
     return float(power)
@@ -144,7 +144,7 @@ def _power(
     proportion: float,
     margin: float,
     size: float,
-    alternative: Literal["lower", "upper"],
+    alternative: Literal["greater", "less"],
     alpha: float,
     phat: bool,
     continuity_correction: bool,
@@ -170,7 +170,7 @@ def solve_power(
     proportion: float,
     margin: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     phat: bool = True,
     continuity_correction: bool = False,
@@ -190,11 +190,11 @@ def solve_power(
             - If `alternative` is `upper`, a positive value must be specified.
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         phat (bool, optional):
@@ -214,7 +214,7 @@ def solve_size(
     null_proportion: float,
     proportion: float,
     margin: float,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -231,13 +231,13 @@ def solve_size(
         margin (float):
             superiority margin ($\\delta$).
 
-            - If `alternative` is `lower`, a negative value must be specified.
-            - If `alternative` is `upper`, a positive value must be specified.
+            - If `alternative` is `greater`, a positive value must be specified.
+            - If `alternative` is `less`, a negative value must be specified.
         alternative (Literal["lower", "upper"], optional):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -264,7 +264,7 @@ def solve_null_proportion(
     proportion: float,
     margin: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -279,15 +279,15 @@ def solve_null_proportion(
         margin (float):
             superiority margin ($\\delta$).
 
-            - If `alternative` is `lower`, a negative value must be specified.
-            - If `alternative` is `upper`, a positive value must be specified.
+            - If `alternative` is `greater`, a positive value must be specified.
+            - If `alternative` is `less`, a negative value must be specified.
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -318,10 +318,10 @@ def solve_null_proportion(
         )
 
     match alternative:
-        case "lower":
-            null_proportion = brentq(func, max(proportion - margin, -margin), 0.999999)
-        case "upper":
+        case "greater":
             null_proportion = brentq(func, 0.000001, min(proportion - margin, 1 - margin))
+        case "less":
+            null_proportion = brentq(func, max(proportion - margin, -margin), 0.999999)
 
     return float(null_proportion)
 
@@ -331,7 +331,7 @@ def solve_proportion(
     null_proportion: float,
     margin: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -346,15 +346,15 @@ def solve_proportion(
         margin (float):
             superiority margin ($\\delta$).
 
-            - If `alternative` is `lower`, a negative value must be specified.
-            - If `alternative` is `upper`, a positive value must be specified.
+            - If `alternative` is `greater`, a positive value must be specified.
+            - If `alternative` is `less`, a negative value must be specified.
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -385,10 +385,10 @@ def solve_proportion(
         )
 
     match alternative:
-        case "lower":
-            proportion = brentq(func, 0.000001, null_proportion + margin)
-        case "upper":
+        case "greater":
             proportion = brentq(func, null_proportion + margin, 0.999999)
+        case "less":
+            proportion = brentq(func, 0.000001, null_proportion + margin)
 
     return float(proportion)
 
@@ -398,7 +398,7 @@ def solve_margin(
     null_proportion: float,
     proportion: float,
     size: int,
-    alternative: Literal["lower", "upper"] = "upper",
+    alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
     phat: bool = True,
@@ -414,11 +414,11 @@ def solve_margin(
             Proportion under the alternative hypothesis ($p$).
         size (int):
             Sample size.
-        alternative (Literal["lower", "upper"], optional):
+        alternative (Literal["greater", "less"]):
             Type of the alternative hypothesis:
 
-            - `'lower'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-            - `'upper'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
+            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
         alpha (float, optional):
             One-sided significance level.
         power (float, optional):
@@ -453,9 +453,9 @@ def solve_margin(
         margin = 0
     else:
         match alternative:
-            case "lower":
-                margin = brentq(func, proportion - null_proportion, 0)
-            case "upper":
+            case "greater":
                 margin = brentq(func, 0, proportion - null_proportion)
+            case "less":
+                margin = brentq(func, proportion - null_proportion, 0)
 
     return float(margin)

--- a/tests/test_correlation/test_ci.py
+++ b/tests/test_correlation/test_ci.py
@@ -14,7 +14,7 @@ class TestCase(BaseTestCase):
     correlation: float
     size: int
     conf_level: float
-    interval_type: Literal["two-sided", "upper", "lower"]
+    interval_type: Literal["two-sided", "lower", "upper"]
     bias_adj: bool
     distance: float
     actual_distance: float
@@ -179,11 +179,6 @@ case_group_bias_adj = (
 
 
 case_group = case_group_not_bias_adj + case_group_bias_adj
-
-
-# @pytest.fixture(params=case_group, ids=generate_id)
-# def case(request: pytest.FixtureRequest) -> TestCase:
-#     return request.param
 
 
 def test_solve_distance(case: TestCase) -> None:

--- a/tests/test_correlation/test_inequality.py
+++ b/tests/test_correlation/test_inequality.py
@@ -12,7 +12,7 @@ from tests.models import BaseTestCase
 class TestCase(BaseTestCase):
     null_correlation: float
     correlation: float
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"]
+    alternative: Literal["two-sided", "greater", "less"]
     size: int
     alpha: float
     power: float
@@ -34,8 +34,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_correlation = 0.70, correlation = 0.80 to 0.85 by 0.01, alternative="upper one-sided", alpha = 0.05, power = 0.80, bias_adj = False
-        TestCase(null_correlation=0.70, correlation=correlation, alternative="upper one-sided", size=size, alpha=0.05, power=0.80, bias_adj=False, actual_power=actual_power)
+        # Regular Test Cases: null_correlation = 0.70, correlation = 0.80 to 0.85 by 0.01, alternative="greater", alpha = 0.05, power = 0.80, bias_adj = False
+        TestCase(null_correlation=0.70, correlation=correlation, alternative="greater", size=size, alpha=0.05, power=0.80, bias_adj=False, actual_power=actual_power)
         for correlation, size, actual_power in [
             (0.80, 119, 0.8013),
             (0.81, 95, 0.8013),
@@ -46,8 +46,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_correlation = 0.70, correlation = 0.50 to 0.55 by 0.01, alternative="lower one-sided", alpha = 0.05, power = 0.80, bias_adj = False
-        TestCase(null_correlation=0.70, correlation=correlation, alternative="lower one-sided", size=size, alpha=0.05, power=0.80, bias_adj=False, actual_power=actual_power)
+        # Regular Test Cases: null_correlation = 0.70, correlation = 0.50 to 0.55 by 0.01, alternative="less", alpha = 0.05, power = 0.80, bias_adj = False
+        TestCase(null_correlation=0.70, correlation=correlation, alternative="less", size=size, alpha=0.05, power=0.80, bias_adj=False, actual_power=actual_power)
         for correlation, size, actual_power in [
             (0.50, 65, 0.8048),
             (0.51, 70, 0.8018),
@@ -70,8 +70,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_correlation = 0.70, correlation = 0.80 to 0.85 by 0.01, alternative="upper one-sided", alpha = 0.05, power = 0.80, bias_adj = True
-        TestCase(null_correlation=0.70, correlation=correlation, alternative="upper one-sided", size=size, alpha=0.05, power=0.80, bias_adj=True, actual_power=actual_power)
+        # Regular Test Cases: null_correlation = 0.70, correlation = 0.80 to 0.85 by 0.01, alternative="greater", alpha = 0.05, power = 0.80, bias_adj = True
+        TestCase(null_correlation=0.70, correlation=correlation, alternative="greater", size=size, alpha=0.05, power=0.80, bias_adj=True, actual_power=actual_power)
         for correlation, size, actual_power in [
             (0.80, 119, 0.8026),
             (0.81, 95, 0.8029),
@@ -82,8 +82,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_correlation = 0.70, correlation = 0.50 to 0.55 by 0.01, alternative="lower one-sided", alpha = 0.05, power = 0.80, bias_adj = True
-        TestCase(null_correlation=0.70, correlation=correlation, alternative="lower one-sided", size=size, alpha=0.05, power=0.80, bias_adj=True, actual_power=actual_power)
+        # Regular Test Cases: null_correlation = 0.70, correlation = 0.50 to 0.55 by 0.01, alternative="less", alpha = 0.05, power = 0.80, bias_adj = True
+        TestCase(null_correlation=0.70, correlation=correlation, alternative="less", size=size, alpha=0.05, power=0.80, bias_adj=True, actual_power=actual_power)
         for correlation, size, actual_power in [
             (0.50, 64, 0.8027),
             (0.51, 70, 0.8049),

--- a/tests/test_mean/test_independent/test_inequality.py
+++ b/tests/test_mean/test_independent/test_inequality.py
@@ -24,7 +24,7 @@ class TestCase(BaseTestCase):
     reference_std: float
     treatment_size: int
     reference_size: int
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"]
+    alternative: Literal["two-sided", "less", "greater"]
     alpha: float
     power: float
     actual_power: float
@@ -39,7 +39,7 @@ class TestCase(BaseTestCase):
 
 case_group = (
     [
-        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "z", equal_var = True
+        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "less", method = "z", equal_var = True
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -48,7 +48,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower one-sided",
+            alternative="less",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -80,7 +80,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "z", equal_var = True
+        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "greater", method = "z", equal_var = True
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -89,7 +89,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper one-sided",
+            alternative="greater",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -162,7 +162,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "z", equal_var = False
+        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "less", method = "z", equal_var = False
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -171,7 +171,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower one-sided",
+            alternative="less",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -203,7 +203,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "z", equal_var = False
+        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "greater", method = "z", equal_var = False
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -212,7 +212,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper one-sided",
+            alternative="greater",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -285,7 +285,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "t", equal_var = True
+        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "less", method = "t", equal_var = True
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -294,7 +294,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower one-sided",
+            alternative="less",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -326,7 +326,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "t", equal_var = True
+        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 40, Ratio = 2, alpha = 0.05, power = 0.80, alternative = "greater", method = "t", equal_var = True
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -335,7 +335,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper one-sided",
+            alternative="greater",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -408,7 +408,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "t", equal_var = False, df_adjust="satterthwaite",
+        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "less", method = "t", equal_var = False, df_adjust="satterthwaite",
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -417,7 +417,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower one-sided",
+            alternative="less",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -450,7 +450,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "t", equal_var = False, df_adjust="satterthwaite",
+        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "greater", method = "t", equal_var = False, df_adjust="satterthwaite",
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -459,7 +459,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper one-sided",
+            alternative="greater",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -534,7 +534,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "t", equal_var = False, df_adjust="welch",
+        # Regular Test Cases: treatment_mean = 0 to 20 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "less", method = "t", equal_var = False, df_adjust="welch",
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -543,7 +543,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower one-sided",
+            alternative="less",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -576,7 +576,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "t", equal_var = False, df_adjust="welch",
+        # Regular Test Cases: treatment_mean = 40 to 60 by 1, reference_mean = 30, treatment_std = 40, reference_std = 30, Ratio = 0.5, alpha = 0.05, power = 0.80, alternative = "greater", method = "t", equal_var = False, df_adjust="welch",
         TestCase(
             treatment_mean=treatment_mean,
             reference_mean=reference_mean,
@@ -585,7 +585,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper one-sided",
+            alternative="greater",
             alpha=0.05,
             power=0.80,
             actual_power=actual_power,
@@ -696,15 +696,9 @@ def test_solve_size(case: TestCase) -> None:
     if (
         case
         in [
-            TestCase(
-                treatment_mean=42, reference_mean=30, diff=12, treatment_std=40, reference_std=40, treatment_size=207, reference_size=104, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8011, method="t", equal_var=True
-            ),
-            TestCase(
-                treatment_mean=47, reference_mean=30, diff=17, treatment_std=40, reference_std=40, treatment_size=103, reference_size=52, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8002, method="t", equal_var=True
-            ),
-            TestCase(
-                treatment_mean=54, reference_mean=30, diff=24, treatment_std=40, reference_std=40, treatment_size=53, reference_size=27, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.808, method="t", equal_var=True
-            ),
+            TestCase(treatment_mean=42, reference_mean=30, diff=12, treatment_std=40, reference_std=40, treatment_size=207, reference_size=104, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8011, method="t", equal_var=True),
+            TestCase(treatment_mean=47, reference_mean=30, diff=17, treatment_std=40, reference_std=40, treatment_size=103, reference_size=52, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8002, method="t", equal_var=True),
+            TestCase(treatment_mean=54, reference_mean=30, diff=24, treatment_std=40, reference_std=40, treatment_size=53, reference_size=27, alternative="greater", alpha=0.05, power=0.8, actual_power=0.808, method="t", equal_var=True),
             TestCase(
                 treatment_mean=52,
                 reference_mean=30,
@@ -713,7 +707,7 @@ def test_solve_size(case: TestCase) -> None:
                 reference_std=30,
                 treatment_size=28,
                 reference_size=56,
-                alternative="upper one-sided",
+                alternative="greater",
                 alpha=0.05,
                 power=0.8,
                 actual_power=0.812,
@@ -746,10 +740,7 @@ def test_solve_size(case: TestCase) -> None:
 
 def test_solve_diff(case: TestCase) -> None:
     if (
-        case
-        == TestCase(
-            treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True
-        )
+        case == TestCase(treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):
@@ -779,10 +770,7 @@ def test_solve_diff(case: TestCase) -> None:
 
 def test_solve_treatment_mean(case: TestCase) -> None:
     if (
-        case
-        == TestCase(
-            treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True
-        )
+        case == TestCase(treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):
@@ -813,10 +801,7 @@ def test_solve_treatment_mean(case: TestCase) -> None:
 
 def test_solve_reference_mean(case: TestCase) -> None:
     if (
-        case
-        == TestCase(
-            treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True
-        )
+        case == TestCase(treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):

--- a/tests/test_mean/test_independent/test_superiority.py
+++ b/tests/test_mean/test_independent/test_superiority.py
@@ -20,7 +20,7 @@ class TestCase(BaseTestCase):
     reference_std: float
     treatment_size: int
     reference_size: int
-    alternative: Literal["lower", "upper"]
+    alternative: Literal["greater", "less"]
     alpha: float
     power: float
     actual_power: float
@@ -40,7 +40,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower",
+            alternative="less",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -71,7 +71,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper",
+            alternative="greater",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -102,7 +102,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower",
+            alternative="less",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -134,7 +134,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper",
+            alternative="greater",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -166,7 +166,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower",
+            alternative="less",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -198,7 +198,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper",
+            alternative="greater",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -230,7 +230,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower",
+            alternative="less",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -261,7 +261,7 @@ case_group = (
             reference_std=40,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper",
+            alternative="greater",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -292,7 +292,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="lower",
+            alternative="less",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -323,7 +323,7 @@ case_group = (
             reference_std=30,
             treatment_size=treatment_size,
             reference_size=reference_size,
-            alternative="upper",
+            alternative="greater",
             alpha=0.025,
             power=0.80,
             actual_power=actual_power,
@@ -372,9 +372,9 @@ def test_solve_power(case: TestCase) -> None:
 
 def test_solve_power_error() -> None:
     with pytest.raises(ValueError):
-        solve_power(diff=0, margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, method="z", equal_var=True)
+        solve_power(diff=0, margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z", equal_var=True)
     with pytest.raises(ValueError):
-        solve_power(treatment_mean=10, margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, method="z")
+        solve_power(treatment_mean=10, margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z")
 
 
 def test_solve_size(case: TestCase) -> None:
@@ -386,7 +386,7 @@ def test_solve_size(case: TestCase) -> None:
         reference_std=40,
         treatment_size=67,
         reference_size=134,
-        alternative="upper",
+        alternative="greater",
         alpha=0.025,
         power=0.8,
         actual_power=0.8051,
@@ -415,15 +415,7 @@ def test_solve_size(case: TestCase) -> None:
 
 def test_solve_size_error() -> None:
     with pytest.raises(ValueError):
-        solve_size(
-            diff=0,
-            margin=10,
-            treatment_std=10,
-            reference_std=20,
-            ratio=1,
-            method="z",
-            equal_var=True,
-        )
+        solve_size(diff=0, margin=10, treatment_std=10, reference_std=20, ratio=1, alternative="greater", method="z", equal_var=True)
 
 
 def test_solve_diff(case: TestCase) -> None:
@@ -435,7 +427,7 @@ def test_solve_diff(case: TestCase) -> None:
         reference_std=40,
         treatment_size=98,
         reference_size=196,
-        alternative="upper",
+        alternative="greater",
         alpha=0.025,
         power=0.8,
         actual_power=0.8037,
@@ -450,7 +442,7 @@ def test_solve_diff(case: TestCase) -> None:
         reference_std=40,
         treatment_size=98,
         reference_size=196,
-        alternative="upper",
+        alternative="greater",
         alpha=0.025,
         power=0.8,
         actual_power=0.8038,
@@ -484,7 +476,7 @@ def test_solve_diff(case: TestCase) -> None:
 
 def test_solve_diff_error() -> None:
     with pytest.raises(ValueError):
-        solve_diff(margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, method="z", equal_var=True)
+        solve_diff(margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z", equal_var=True)
 
 
 def test_solve_margin(case: TestCase) -> None:
@@ -512,7 +504,7 @@ def test_solve_margin(case: TestCase) -> None:
 
 def test_solve_margin_error() -> None:
     with pytest.raises(ValueError):
-        solve_margin(diff=0, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, method="z", equal_var=True)
+        solve_margin(diff=0, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z", equal_var=True)
 
 
 def test_solve_treatment_std(case: TestCase) -> None:
@@ -540,9 +532,9 @@ def test_solve_treatment_std(case: TestCase) -> None:
 
 def test_solve_treatment_std_error() -> None:
     with pytest.raises(ValueError):
-        solve_treatment_std(diff=0, margin=10, treatment_size=20, reference_size=20, equal_var=False)
+        solve_treatment_std(diff=0, margin=10, treatment_size=20, reference_size=20, alternative="greater", equal_var=False)
     with pytest.raises(ValueError):
-        solve_treatment_std(treatment_mean=10, margin=10, treatment_size=20, reference_size=20)
+        solve_treatment_std(treatment_mean=10, margin=10, treatment_size=20, alternative="greater", reference_size=20)
 
 
 def test_solve_reference_std(case: TestCase) -> None:
@@ -570,6 +562,6 @@ def test_solve_reference_std(case: TestCase) -> None:
 
 def test_solve_reference_std_error() -> None:
     with pytest.raises(ValueError):
-        solve_reference_std(diff=0, margin=10, treatment_size=20, reference_size=20, equal_var=False)
+        solve_reference_std(diff=0, margin=10, treatment_size=20, reference_size=20, alternative="greater", equal_var=False)
     with pytest.raises(ValueError):
-        solve_reference_std(treatment_mean=10, margin=10, treatment_size=20, reference_size=20, equal_var=False)
+        solve_reference_std(treatment_mean=10, margin=10, treatment_size=20, reference_size=20, alternative="greater", equal_var=False)

--- a/tests/test_mean/test_single/test_inequality.py
+++ b/tests/test_mean/test_single/test_inequality.py
@@ -17,7 +17,7 @@ class TestCase(BaseTestCase):
     mean: float
     std: float
     size: int
-    alternative: Literal["two-sided", "lower one-sided", "upper one-sided"]
+    alternative: Literal["two-sided", "less", "greater"]
     alpha: float
     power: float
     actual_power: float
@@ -26,8 +26,8 @@ class TestCase(BaseTestCase):
 
 case_group = (
     [
-        # Regular Test Cases: null_mean = 30 to 40 by 1, mean = 20, std = 20, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "z"
-        TestCase(null_mean=null_mean, mean=20, std=20, size=size, alternative="lower one-sided", alpha=0.05, power=0.80, actual_power=actual_power, method="z")
+        # Regular Test Cases: null_mean = 30 to 40 by 1, mean = 20, std = 20, alpha = 0.05, power = 0.80, alternative = "less", method = "z"
+        TestCase(null_mean=null_mean, mean=20, std=20, size=size, alternative="less", alpha=0.05, power=0.80, actual_power=actual_power, method="z")
         for null_mean, size, actual_power in [
             (30, 25, 0.8038),
             (31, 21, 0.8094),
@@ -43,8 +43,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_mean = 20, mean = 30 to 40 by 1, std = 20, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "z"
-        TestCase(null_mean=20, mean=mean, std=20, size=size, alternative="upper one-sided", alpha=0.05, power=0.80, actual_power=actual_power, method="z")
+        # Regular Test Cases: null_mean = 20, mean = 30 to 40 by 1, std = 20, alpha = 0.05, power = 0.80, alternative = "greater", method = "z"
+        TestCase(null_mean=20, mean=mean, std=20, size=size, alternative="greater", alpha=0.05, power=0.80, actual_power=actual_power, method="z")
         for mean, size, actual_power in [
             (30, 25, 0.8038),
             (31, 21, 0.8094),
@@ -77,8 +77,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_mean = 30 to 40 by 1, mean = 20, std = 20, alpha = 0.05, power = 0.80, alternative = "lower one-sided", method = "t"
-        TestCase(null_mean=null_mean, mean=20, std=20, size=size, alternative="lower one-sided", alpha=0.05, power=0.80, actual_power=actual_power, method="t")
+        # Regular Test Cases: null_mean = 30 to 40 by 1, mean = 20, std = 20, alpha = 0.05, power = 0.80, alternative = "less", method = "t"
+        TestCase(null_mean=null_mean, mean=20, std=20, size=size, alternative="less", alpha=0.05, power=0.80, actual_power=actual_power, method="t")
         for null_mean, size, actual_power in [
             (30, 27, 0.8118),
             (31, 22, 0.8024),
@@ -94,8 +94,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Test Cases: null_mean = 20, mean = 30 to 40 by 1, std = 20, alpha = 0.05, power = 0.80, alternative = "upper one-sided", method = "t"
-        TestCase(null_mean=20, mean=mean, std=20, size=size, alternative="upper one-sided", alpha=0.05, power=0.80, actual_power=actual_power, method="t")
+        # Regular Test Cases: null_mean = 20, mean = 30 to 40 by 1, std = 20, alpha = 0.05, power = 0.80, alternative = "greater", method = "t"
+        TestCase(null_mean=20, mean=mean, std=20, size=size, alternative="greater", alpha=0.05, power=0.80, actual_power=actual_power, method="t")
         for mean, size, actual_power in [
             (30, 27, 0.8118),
             (31, 22, 0.8024),
@@ -142,7 +142,7 @@ def test_solve_power(case: TestCase) -> None:
 
 def test_solve_size(case: TestCase) -> None:
     if case in [
-        TestCase(null_mean=20, mean=40, std=20, size=8, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
+        TestCase(null_mean=20, mean=40, std=20, size=8, alternative="greater", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
         TestCase(null_mean=20, mean=30, std=20, size=34, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8078, method="t"),
         TestCase(null_mean=20, mean=31, std=20, size=28, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8011, method="t"),
         TestCase(null_mean=20, mean=32, std=20, size=24, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8037, method="t"),
@@ -161,9 +161,9 @@ def test_solve_size(case: TestCase) -> None:
 
 def test_solve_null_mean(case: TestCase) -> None:
     if case in [
-        TestCase(null_mean=20, mean=33, std=20, size=17, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.821, method="t"),
-        TestCase(null_mean=20, mean=34, std=20, size=15, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8243, method="t"),
-        TestCase(null_mean=20, mean=40, std=20, size=8, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
+        TestCase(null_mean=20, mean=33, std=20, size=17, alternative="greater", alpha=0.05, power=0.8, actual_power=0.821, method="t"),
+        TestCase(null_mean=20, mean=34, std=20, size=15, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8243, method="t"),
+        TestCase(null_mean=20, mean=40, std=20, size=8, alternative="greater", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
         TestCase(null_mean=20, mean=30, std=20, size=34, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8078, method="t"),
         TestCase(null_mean=20, mean=31, std=20, size=28, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8011, method="t"),
         TestCase(null_mean=20, mean=32, std=20, size=24, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8037, method="t"),
@@ -190,9 +190,9 @@ def test_solve_null_mean(case: TestCase) -> None:
 
 def test_solve_mean(case: TestCase) -> None:
     if case in [
-        TestCase(null_mean=20, mean=33, std=20, size=17, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.821, method="t"),
-        TestCase(null_mean=20, mean=34, std=20, size=15, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.8243, method="t"),
-        TestCase(null_mean=20, mean=40, std=20, size=8, alternative="upper one-sided", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
+        TestCase(null_mean=20, mean=33, std=20, size=17, alternative="greater", alpha=0.05, power=0.8, actual_power=0.821, method="t"),
+        TestCase(null_mean=20, mean=34, std=20, size=15, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8243, method="t"),
+        TestCase(null_mean=20, mean=40, std=20, size=8, alternative="greater", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
         TestCase(null_mean=20, mean=30, std=20, size=34, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8078, method="t"),
         TestCase(null_mean=20, mean=31, std=20, size=28, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8011, method="t"),
         TestCase(null_mean=20, mean=32, std=20, size=24, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8037, method="t"),

--- a/tests/test_proportion/test_independent/test_ci.py
+++ b/tests/test_proportion/test_independent/test_ci.py
@@ -16,7 +16,7 @@ class TestCase(BaseTestCase):
     treatment_size: int
     reference_size: int
     conf_level: float
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"]
+    interval_type: Literal["two-sided", "lower", "upper"]
     method: Literal["chisq", "chisq_cc", "newcombe_wilson", "newcombe_wilson_cc", "farrington_manning", "miettinen_nurminen"]
     distance: float
     actual_distance: float
@@ -59,14 +59,14 @@ case_group_chisq = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower one-sided", method = "chisq"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower", method = "chisq"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="lower one-sided",
+            interval_type="lower",
             method="chisq",
             distance=distance,
             actual_distance=actual_distance,
@@ -94,14 +94,14 @@ case_group_chisq = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "chisq"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "chisq"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="chisq",
             distance=distance,
             actual_distance=actual_distance,
@@ -202,14 +202,14 @@ case_group_chisq_cc = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower one-sided", method = "chisq_cc"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower", method = "chisq_cc"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="lower one-sided",
+            interval_type="lower",
             method="chisq_cc",
             distance=distance,
             actual_distance=actual_distance,
@@ -237,14 +237,14 @@ case_group_chisq_cc = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "chisq_cc"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "chisq_cc"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="chisq_cc",
             distance=distance,
             actual_distance=actual_distance,
@@ -311,14 +311,14 @@ case_group_newcombe_wilson = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower one-sided", method = "newcombe_wilson"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower", method = "newcombe_wilson"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="lower one-sided",
+            interval_type="lower",
             method="newcombe_wilson",
             distance=distance,
             actual_distance=actual_distance,
@@ -346,14 +346,14 @@ case_group_newcombe_wilson = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "newcombe_wilson"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "newcombe_wilson"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="newcombe_wilson",
             distance=distance,
             actual_distance=actual_distance,
@@ -381,14 +381,14 @@ case_group_newcombe_wilson = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.90, reference_proportion = 0.05 to 0.95 by 0.01, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "newcombe_wilson"
+        # Regular Cases: treatment_proportion = 0.90, reference_proportion = 0.05 to 0.95 by 0.01, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "newcombe_wilson"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="newcombe_wilson",
             distance=distance,
             actual_distance=actual_distance,
@@ -455,14 +455,14 @@ case_group_newcombe_wilson_cc = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower one-sided", method = "newcombe_wilson_cc"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower", method = "newcombe_wilson_cc"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="lower one-sided",
+            interval_type="lower",
             method="newcombe_wilson_cc",
             distance=distance,
             actual_distance=actual_distance,
@@ -490,14 +490,14 @@ case_group_newcombe_wilson_cc = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "newcombe_wilson_cc"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "newcombe_wilson_cc"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="newcombe_wilson_cc",
             distance=distance,
             actual_distance=actual_distance,
@@ -564,14 +564,14 @@ case_group_farrington_manning = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower one-sided", method = "farrington_manning"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower", method = "farrington_manning"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="lower one-sided",
+            interval_type="lower",
             method="farrington_manning",
             distance=distance,
             actual_distance=actual_distance,
@@ -599,14 +599,14 @@ case_group_farrington_manning = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "farrington_manning"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "farrington_manning"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="farrington_manning",
             distance=distance,
             actual_distance=actual_distance,
@@ -672,14 +672,14 @@ case_group_miettinen_nurminen = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower one-sided", method = "miettinen_nurminen"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 2, distance = 0.1, conf_level = 0.95, interval_type = "lower", method = "miettinen_nurminen"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="lower one-sided",
+            interval_type="lower",
             method="miettinen_nurminen",
             distance=distance,
             actual_distance=actual_distance,
@@ -707,14 +707,14 @@ case_group_miettinen_nurminen = (
         ]
     ]
     + [
-        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper one-sided", method = "miettinen_nurminen"
+        # Regular Cases: treatment_proportion = 0.05 to 0.95 by 0.05, reference_proportion = 0.50, ratio = 0.5, distance = 0.1, conf_level = 0.95, interval_type = "upper", method = "miettinen_nurminen"
         TestCase(
             treatment_proportion=treatment_proportion,
             reference_proportion=reference_proportion,
             treatment_size=treatment_size,
             reference_size=reference_size,
             conf_level=0.95,
-            interval_type="upper one-sided",
+            interval_type="upper",
             method="miettinen_nurminen",
             distance=distance,
             actual_distance=actual_distance,

--- a/tests/test_proportion/test_single/test_ci.py
+++ b/tests/test_proportion/test_single/test_ci.py
@@ -18,7 +18,7 @@ class TestCase(BaseTestCase):
     distance: float
     actual_distance: float
     conf_level: float
-    interval_type: Literal["two-sided", "lower one-sided", "upper one-sided"]
+    interval_type: Literal["two-sided", "lower", "upper"]
     method: Literal["clopper-pearson", "wald", "wilson"]
     continuity_correction: bool | None = None
 
@@ -41,8 +41,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower one-sided", method = "clopper-pearson"
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower one-sided", method="clopper-pearson")
+        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "clopper-pearson"
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="clopper-pearson")
         for size, distance, actual_distance in [
             (2704, 0.01, 0.0100),
             (742, 0.02, 0.0200),
@@ -57,8 +57,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper one-sided", method = "clopper-pearson"
-        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper one-sided", method="clopper-pearson")
+        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "clopper-pearson"
+        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="clopper-pearson")
         for size, distance, actual_distance in [
             (4298, 0.01, 0.0100),
             (1065, 0.02, 0.0200),
@@ -89,8 +89,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower one-sided", method = "wald", continuity_correction = False
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower one-sided", method="wald", continuity_correction=False)
+        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wald", continuity_correction = False
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wald", continuity_correction=False)
         for size, distance, actual_distance in [
             (2435, 0.01, 0.0100),
             (609, 0.02, 0.0200),
@@ -105,8 +105,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper one-sided", method = "wald", continuity_correction = False
-        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper one-sided", method="wald", continuity_correction=False)
+        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wald", continuity_correction = False
+        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wald", continuity_correction=False)
         for size, distance, actual_distance in [
             (4329, 0.01, 0.0100),
             (1083, 0.02, 0.0200),
@@ -137,8 +137,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower one-sided", method = "wald", continuity_correction = True
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower one-sided", method="wald", continuity_correction=True)
+        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wald", continuity_correction = True
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wald", continuity_correction=True)
         for size, distance, actual_distance in [
             (2535, 0.01, 0.0100),
             (658, 0.02, 0.0200),
@@ -153,8 +153,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper one-sided", method = "wald", continuity_correction = True
-        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper one-sided", method="wald", continuity_correction=True)
+        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wald", continuity_correction = True
+        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wald", continuity_correction=True)
         for size, distance, actual_distance in [
             (4429, 0.01, 0.0100),
             (1132, 0.02, 0.0200),
@@ -185,8 +185,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower one-sided", method = "wilson", continuity_correction = False
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower one-sided", method="wilson", continuity_correction=False)
+        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wilson", continuity_correction = False
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wilson", continuity_correction=False)
         for size, distance, actual_distance in [
             (2649, 0.01, 0.0100),
             (715, 0.02, 0.0200),
@@ -201,8 +201,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper one-sided", method = "wilson", continuity_correction = False
-        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper one-sided", method="wilson", continuity_correction=False)
+        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wilson", continuity_correction = False
+        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wilson", continuity_correction=False)
         for size, distance, actual_distance in [
             (4164, 0.01, 0.0100),
             (999, 0.02, 0.0200),
@@ -233,8 +233,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower one-sided", method = "wilson", continuity_correction = True
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower one-sided", method="wilson", continuity_correction=True)
+        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wilson", continuity_correction = True
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wilson", continuity_correction=True)
         for size, distance, actual_distance in [
             (2748, 0.01, 0.0100),
             (764, 0.02, 0.0200),
@@ -249,8 +249,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper one-sided", method = "wilson", continuity_correction = True
-        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper one-sided", method="wilson", continuity_correction=True)
+        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wilson", continuity_correction = True
+        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wilson", continuity_correction=True)
         for size, distance, actual_distance in [
             (4264, 0.01, 0.0100),
             (1048, 0.02, 0.0200),

--- a/tests/test_proportion/test_single/test_noninferiority.py
+++ b/tests/test_proportion/test_single/test_noninferiority.py
@@ -15,7 +15,7 @@ class TestCase(BaseTestCase):
     proportion: float
     margin: float
     size: int
-    alternative: Literal["lower", "upper"]
+    alternative: Literal["greater", "less"]
     alpha: float
     power: float
     phat: bool
@@ -25,8 +25,8 @@ class TestCase(BaseTestCase):
 
 case_group = (
     [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "upper", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="upper", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
+        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.80, 563, 0.8007),
             (0.81, 387, 0.8011),
@@ -47,8 +47,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "lower", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="lower", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.65, 31, 0.8071),
             (0.66, 34, 0.8055),
@@ -69,8 +69,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "upper", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="upper", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
+        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.80, 582, 0.8001),
             (0.81, 403, 0.8005),
@@ -91,8 +91,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "lower", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="lower", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.65, 36, 0.8089),
             (0.66, 39, 0.8047),
@@ -113,8 +113,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "upper", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="upper", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
+        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.80, 503, 0.8005),
             (0.81, 336, 0.8005),
@@ -135,8 +135,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "lower", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="lower", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.65, 45, 0.8031),
             (0.66, 49, 0.8017),
@@ -157,8 +157,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "upper", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="upper", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
+        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.80, 523, 0.8007),
             (0.81, 353, 0.8012),
@@ -179,8 +179,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "lower", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="lower", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.65, 50, 0.8042),
             (0.66, 54, 0.8006),

--- a/tests/test_proportion/test_single/test_superiority.py
+++ b/tests/test_proportion/test_single/test_superiority.py
@@ -15,7 +15,7 @@ class TestCase(BaseTestCase):
     proportion: float
     margin: float
     size: int
-    alternative: Literal["lower", "upper"]
+    alternative: Literal["greater", "less"]
     alpha: float
     power: float
     phat: bool
@@ -25,8 +25,8 @@ class TestCase(BaseTestCase):
 
 case_group = (
     [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "upper", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="upper", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "greater", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="greater", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.81, 12414, 0.8000),
             (0.82, 3066, 0.8001),
@@ -46,8 +46,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "lower", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="lower", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "less", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
+        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="less", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.55, 78, 0.8044),
             (0.56, 89, 0.8027),
@@ -67,8 +67,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "upper", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="upper", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "greater", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="greater", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.81, 12514, 0.8000),
             (0.82, 3116, 0.8001),
@@ -88,8 +88,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "lower", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="lower", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "less", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
+        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="less", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.55, 84, 0.8019),
             (0.56, 96, 0.8027),
@@ -109,8 +109,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "upper", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="upper", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.81, 12080, 0.8000),
             (0.82, 2897, 0.8001),
@@ -130,8 +130,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "lower", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="lower", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "less", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
+        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="less", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.55, 87, 0.8030),
             (0.56, 99, 0.8013),
@@ -151,8 +151,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "upper", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="upper", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.81 to 0.95 by 0.01, margin = 0.05, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
+        TestCase(null_proportion=0.75, proportion=proportion, margin=0.05, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.81, 12180, 0.8000),
             (0.82, 2947, 0.8001),
@@ -172,8 +172,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "lower", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="lower", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.75, proportion = 0.55 to 0.69 by 0.01, margin = -0.05, alternative = "less", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
+        TestCase(null_proportion=0.75, proportion=proportion, margin=-0.05, size=size, alternative="less", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.55, 93, 0.8005),
             (0.56, 106, 0.8012),
@@ -193,8 +193,8 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: null_proportion = 0.80, proportion = 0.81 to 0.95 by 0.01, margin = 0, alternative = "upper", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.80, proportion=proportion, margin=0, size=size, alternative="upper", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
+        # Regular Cases: null_proportion = 0.80, proportion = 0.81 to 0.95 by 0.01, margin = 0, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
+        TestCase(null_proportion=0.80, proportion=proportion, margin=0, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
         for proportion, size, actual_power in [
             (0.81, 12180, 0.800025301),
             (0.82, 2947, 0.800132046),


### PR DESCRIPTION
### **User description**
- For the confidence interval module, the `interval_type` options should be: `two-sided`, `lower`, `upper`; 
- For the hypothesis testing module, the `alternative` options should be: `two-sided`, `greater`, `less`;


___

### **PR Type**
Enhancement


___

### **Description**
- Rename `alternative` options in hypothesis testing from "lower one-sided"/"upper one-sided" (or "lower"/"upper") to "greater" and "less" for consistency.

- Rename `interval_type` options in confidence interval functions to "lower" and "upper".

- Update all internal function signatures, match-case branches, and docstrings to reflect the new names.

- Apply changes across multiple modules: mean (independent, single), correlation, and proportion (independent, single).


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["old: 'lower one-sided' / 'lower' in tests"] --> B["new: 'less'"]
  C["old: 'upper one-sided' / 'upper' in tests"] --> D["new: 'greater'"]
  E["old: 'lower one-sided' in CIs"] --> F["new: 'lower'"]
  G["old: 'upper one-sided' in CIs"] --> H["new: 'upper'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>inequality.py</strong><dd><code>Switch hypothesis test alternative options to "greater"/"less"</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-fe994647e98db728d902ed3f00786c03e9765905ffb8f8eb1e7c71f9dd0e3b46">+56/-56</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ci.py</strong><dd><code>Change confidence interval type options to "lower"/"upper"</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-473b8a4b61412b24759311a567643851654e78836b4767afd559028bee22b4d3">+35/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>superiority.py</strong><dd><code>Replace "lower"/"upper" alternative options with "greater"/"less"</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-3aedf930efbf3ef56e29260dafeb6fe935c9d5ad5992b9fbfcabcece7c17c70a">+45/-45</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>superiority.py</strong><dd><code>Unify alternative options to "greater"/"less" for superiority tests</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-8a2eeb3029983a36532fe577d9ec0a0a6409b84294119d8b81a1d36dc4ead187">+46/-46</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ci.py</strong><dd><code>Rename confidence interval type options to "lower"/"upper"</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-cf0b984c0d1673d5ec89623683697dbebfe7e4cbc4e9108c01843a7ad873b2fc">+27/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>noninferiority.py</strong><dd><code>Migrate alternative options to "greater"/"less" for noninferiority</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-0f631e564e15ef88a2e51acf84a7fab4ce67cf0bba5dc33009bf2326f17b5f84">+41/-41</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>inequality.py</strong><dd><code>Adopt "greater"/"less" for correlation test alternative</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-164e0ef20ca41c26caba4a1824cd583968671ced1f747023aa37706b20bbc1e3">+32/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ci.py</strong><dd><code>Standardise CI type options to "lower"/"upper" and reorder cases</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-0d3b3ef278b7591b78bb8b40bf86e143dbd51e1445163f4dbea24dc5ea36f01b">+28/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>inequality.py</strong><dd><code>Convert single-mean test alternative options to "greater"/"less"</code></dd></td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/422/files#diff-8731eff3663401fff7861863df12de3c48859a715ec67a54cc7b0dc1d8799ccd">+33/-33</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

