### PR TITLE
chore: add `helpers:pinGitHubActionDigests` to automatically pin action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "dependencyDashboard": false,
   "labels": ["dependencies"],
   "rangeStrategy": "bump",


### PR DESCRIPTION
### **User description**
This PR add a renovate config `helpers:pinGitHubActionDigests`, which helps to pin action digests automatically.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `helpers:pinGitHubActionDigests` to Renovate extends

- Enables automatic pinning of GitHub Actions digests


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Add pinGitHubActionDigests helper to renovate config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

- Add `"helpers:pinGitHubActionDigests"` to the `extends` array


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/424/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

