### PR TITLE
docs(mean.independent.noninferiority): remove the absolute value form of power formula

### DIFF
--- a/docs/algorithms/mean/independent/noninferiority.md
+++ b/docs/algorithms/mean/independent/noninferiority.md
@@ -61,21 +61,11 @@ $$
     = 1 - \Phi\left(z_{1-\alpha} + \frac{\mu_1 - \mu_2 - \delta}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     $$
 
-在 $H_1$ 成立时：
-
-若 $\delta < 0$，则 $\mu_1 - \mu_2 - \delta > 0$；
-
-若 $\delta > 0$，则 $\mu_1 - \mu_2 - \delta < 0$。
-
-$$
-\text{Power} = 1 - \Phi\left(z_{1-\alpha} - \frac{\left|\mu_1 - \mu_2 - \delta\right|}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
-$$
-
 ??? note "样本量公式推导"
     根据标准正态分布分位数的定义：
 
     $$
-    z_{1-\alpha} - \frac{\left|\mu_1 - \mu_2 - \delta\right|}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} = z_\beta
+    z_{1-\alpha} \pm \frac{\mu_1 - \mu_2 - \delta}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} = z_\beta
     $$
 
     设 $n_1 = kn_2$，由上式可解出
@@ -124,21 +114,11 @@ $$
     = 1 - \Phi\left(z_{1-\alpha} + \frac{\mu_1 - \mu_2 - \delta}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
     $$
 
-在 $H_1$ 成立时：
-
-若 $\delta < 0$，则 $\mu_1 - \mu_2 - \delta > 0$；
-
-若 $\delta > 0$，则 $\mu_1 - \mu_2 - \delta < 0$。
-
-$$
-\text{Power} = 1 - \Phi\left(z_{1-\alpha} - \frac{\left|\mu_1 - \mu_2 - \delta\right|}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
-$$
-
 ??? note "样本量公式推导"
     根据标准正态分布分位数的定义：
 
     $$
-    z_{1-\alpha} - \frac{\left|\mu_1 - \mu_2 - \delta\right|}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} = z_\beta
+    z_{1-\alpha} \pm \frac{\mu_1 - \mu_2 - \delta}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} = z_\beta
     $$
 
     设 $n_1 = kn_2$，由上式可解出


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Removed absolute value notation from the power formula for independent non-inferiority test.

- Replaced absolute value with `±` sign in the sample size derivation.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>noninferiority.md</strong><dd><code>Remove absolute value from power formula derivation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/algorithms/mean/independent/noninferiority.md

<ul><li>Removed absolute value power formula and its sign justification<br> <li> Replaced absolute value with <code>±</code> in sample size derivation equations</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/427/files#diff-177f7f02066ab78d7d84a399c17eb2879f14224f7254376665ac5f7b04258b81">+2/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

