### PR TITLE
fix(mean.independent.noninferiority): correct internal function names and fix typo

### DIFF
--- a/src/pystatpower/mean/independent/noninferiority.py
+++ b/src/pystatpower/mean/independent/noninferiority.py
@@ -298,8 +298,8 @@ def solve_power(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -318,8 +318,8 @@ def solve_power(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -411,8 +411,8 @@ def solve_size(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -429,8 +429,8 @@ def solve_size(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -547,8 +547,8 @@ def solve_treatment_mean(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -567,8 +567,8 @@ def solve_treatment_mean(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -660,8 +660,8 @@ def solve_reference_mean(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -680,8 +680,8 @@ def solve_reference_mean(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -770,8 +770,8 @@ def solve_diff(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -790,8 +790,8 @@ def solve_diff(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -906,8 +906,8 @@ def solve_margin(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -1013,8 +1013,8 @@ def solve_treatment_std(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         reference_std:
             Standard deviation in the reference group.
 
@@ -1029,8 +1029,8 @@ def solve_treatment_std(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 
@@ -1191,8 +1191,8 @@ def solve_reference_std(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `-abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
 
@@ -1203,8 +1203,8 @@ def solve_reference_std(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 

--- a/src/pystatpower/mean/independent/noninferiority.py
+++ b/src/pystatpower/mean/independent/noninferiority.py
@@ -141,7 +141,7 @@ def _power_t_equal_var(
     return power
 
 
-def _power_unequal_var_welch(
+def _power_t_unequal_var_welch(
     diff: float,
     margin: float,
     treatment_std: float,
@@ -171,7 +171,7 @@ def _power_unequal_var_welch(
     return power
 
 
-def _power_unequal_var_satterthwaite(
+def _power_t_unequal_var_satterthwaite(
     diff: float,
     margin: float,
     treatment_std: float,
@@ -234,7 +234,7 @@ def _power(
             else:
                 match approx_t_method:
                     case "welch":
-                        power = _power_unequal_var_welch(
+                        power = _power_t_unequal_var_welch(
                             diff,
                             margin,
                             treatment_std,
@@ -245,7 +245,7 @@ def _power(
                             alpha,
                         )
                     case "satterthwaite":
-                        power = _power_unequal_var_satterthwaite(
+                        power = _power_t_unequal_var_satterthwaite(
                             diff,
                             margin,
                             treatment_std,
@@ -903,6 +903,11 @@ def solve_margin(
             Sample size for the treatment group.
         reference_size:
             Sample size for the reference group.
+        alternative:
+            Type of the alternative hypothesis.
+
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta < 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta > 0$)
         alpha:
             Significance level.
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Renamed internal functions for unequal variances to include '_t_' prefix for consistency.

- Updated all references to the renamed functions in `_power`.

- Added missing docstring for the `alternative` parameter in `solve_margin`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rename _power_unequal_var_welch and _power_unequal_var_satterthwaite"] -- "to" --> B["_power_t_unequal_var_welch and _power_t_unequal_var_satterthwaite"]
  C["Missing 'alternative' docstring"] -- "added" --> D["solve_margin parameter documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>noninferiority.py</strong><dd><code>Rename internal functions and add missing docstring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/mean/independent/noninferiority.py

<ul><li>Renamed internal functions <code>_power_unequal_var_welch</code> to <br><code>_power_t_unequal_var_welch</code> and <code>_power_unequal_var_satterthwaite</code> to <br><code>_power_t_unequal_var_satterthwaite</code> for consistency.<br> <li> Updated function calls in <code>_power</code> to use the new names.<br> <li> Added docstring for the <code>alternative</code> parameter in <code>solve_margin</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/432/files#diff-e0a9bee20da96edc9a9808ee41907be38f378b17c55a3ca0f16889d129d5e9e2">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

