### PR TITLE
refactor(mean.independent.noninferiority): extract the common internal function

### DIFF
--- a/src/pystatpower/mean/independent/_power.py
+++ b/src/pystatpower/mean/independent/_power.py
@@ -1,0 +1,210 @@
+from math import sqrt
+from typing import Literal
+
+from scipy.stats import nct, norm, t
+
+
+def _power_z_equal_var(
+    diff: float,
+    margin: float,
+    std: float,
+    treatment_size: float,
+    reference_size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the power of two independent mean difference test, using z test, assuming equal variances."""
+
+    se = std * sqrt(1 / treatment_size + 1 / reference_size)
+
+    match alternative:
+        case "two-sided":
+            power = (
+                1
+                - norm.cdf(norm.ppf(1 - alpha / 2) - (diff - margin) / se)
+                + norm.cdf(norm.ppf(alpha / 2) - (diff - margin) / se)
+            )
+        case "greater":
+            power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
+
+    return float(power)
+
+
+def _power_z_unequal_var(
+    diff: float,
+    margin: float,
+    treatment_std: float,
+    reference_std: float,
+    treatment_size: float,
+    reference_size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the power of two independent mean difference test, using z test, assuming unequal variances."""
+
+    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
+
+    match alternative:
+        case "two-sided":
+            power = (
+                1
+                - norm.cdf(norm.ppf(1 - alpha / 2) - (diff - margin) / se)
+                + norm.cdf(norm.ppf(alpha / 2) - (diff - margin) / se)
+            )
+        case "greater":
+            power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
+
+    return float(power)
+
+
+def _power_t_equal_var(
+    diff: float,
+    margin: float,
+    treatment_std: float,
+    reference_std: float,
+    treatment_size: float,
+    reference_size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the power of two independent mean difference test, using t test, assuming equal variances."""
+
+    df = treatment_size + reference_size - 2
+    se = sqrt(
+        ((treatment_size - 1) * treatment_std**2 + (reference_size - 1) * reference_std**2)
+        / df
+        * (1 / treatment_size + 1 / reference_size)
+    )
+    nc = (diff - margin) / se
+
+    match alternative:
+        case "two-sided":
+            power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
+        case "greater":
+            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
+
+    return power
+
+
+def _power_t_unequal_var_welch(
+    diff: float,
+    margin: float,
+    treatment_std: float,
+    reference_std: float,
+    treatment_size: float,
+    reference_size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the power of two independent mean difference test, using Welch's approximate t test."""
+
+    df = (treatment_std**2 / treatment_size + reference_std**2 / reference_size) ** 2 / (
+        treatment_std**4 / (treatment_size**2 * (treatment_size + 1))
+        + reference_std**4 / (reference_size**2 * (reference_size + 1))
+    ) - 2
+    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
+    nc = (diff - margin) / se
+
+    match alternative:
+        case "two-sided":
+            power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
+        case "greater":
+            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
+
+    return power
+
+
+def _power_t_unequal_var_satterthwaite(
+    diff: float,
+    margin: float,
+    treatment_std: float,
+    reference_std: float,
+    treatment_size: float,
+    reference_size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the power of two independent mean difference test, using Satterthwaite's approximate t test."""
+
+    df = (treatment_std**2 / treatment_size + reference_std**2 / reference_size) ** 2 / (
+        treatment_std**4 / (treatment_size**2 * (treatment_size - 1))
+        + reference_std**4 / (reference_size**2 * (reference_size - 1))
+    )
+    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
+    nc = (diff - margin) / se
+
+    match alternative:
+        case "two-sided":
+            power = 1 - nct.cdf(t.ppf(1 - alpha / 2, df), df, nc) + nct.cdf(t.ppf(alpha / 2, df), df, nc)
+        case "greater":
+            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+        case "less":
+            power = nct.cdf(t.ppf(alpha, df), df, nc)
+
+    return power
+
+
+def _power(
+    *,
+    diff: float | None = None,
+    margin: float,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
+    treatment_size: float,
+    reference_size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+    dist: Literal["z", "t"],
+    equal_var: bool,
+    approx_t_method: Literal["welch", "satterthwaite"],
+) -> float:
+    """Calculate the power of two independent mean difference test."""
+
+    match dist:
+        case "z":
+            if equal_var:
+                power = _power_z_equal_var(diff, margin, std, treatment_size, reference_size, alternative, alpha)
+            else:
+                power = _power_z_unequal_var(
+                    diff, margin, treatment_std, reference_std, treatment_size, reference_size, alternative, alpha
+                )
+        case "t":
+            if equal_var:
+                power = _power_t_equal_var(
+                    diff, margin, treatment_std, reference_std, treatment_size, reference_size, alternative, alpha
+                )
+            else:
+                match approx_t_method:
+                    case "welch":
+                        power = _power_t_unequal_var_welch(
+                            diff,
+                            margin,
+                            treatment_std,
+                            reference_std,
+                            treatment_size,
+                            reference_size,
+                            alternative,
+                            alpha,
+                        )
+                    case "satterthwaite":
+                        power = _power_t_unequal_var_satterthwaite(
+                            diff,
+                            margin,
+                            treatment_std,
+                            reference_std,
+                            treatment_size,
+                            reference_size,
+                            alternative,
+                            alpha,
+                        )
+
+    return power

--- a/src/pystatpower/mean/independent/_verify.py
+++ b/src/pystatpower/mean/independent/_verify.py
@@ -1,0 +1,53 @@
+from typing import Literal
+
+
+def _verify_mean_and_get_diff(
+    treatment_mean: float | None,
+    reference_mean: float | None,
+    diff: float | None,
+) -> float:
+
+    if diff is None:
+        if treatment_mean is None or reference_mean is None:
+            raise ValueError("When 'diff' is omitted, both 'treatment_mean' and 'reference_mean' must be provided.")
+        diff = treatment_mean - reference_mean
+
+    return diff
+
+
+def _verify_std_and_get_std(
+    treatment_std: float | None,
+    reference_std: float | None,
+    std: float | None,
+    dist: Literal["z", "t"],
+    equal_var: bool,
+) -> float:
+
+    if dist == "z":
+        if equal_var:
+            if std is None:
+                if treatment_std is None and reference_std is None:
+                    raise ValueError(
+                        "For 'z' test with equal variance, at least one of 'std', 'treatment_std', or 'reference_std' must be specified."
+                    )
+                elif treatment_std is not None and reference_std is not None:
+                    if treatment_std != reference_std:
+                        raise ValueError(
+                            "For 'z' test with equal variance, when 'std' is omitted and both 'treatment_std' and 'reference_std' are supplied, they must be equal."
+                        )
+                    else:  # treatment_std == reference_std
+                        std = treatment_std
+                elif treatment_std is None and reference_std is not None:
+                    std = reference_std
+                else:  # treatment_std is not None and reference_std is None:
+                    std = treatment_std
+        else:  # equal_var == False
+            if treatment_std is None or reference_std is None:
+                raise ValueError(
+                    "For z-test with unequal variance, both 'treatment_std' and 'reference_std' must be specified."
+                )
+    else:  # dist == "t"
+        if treatment_std is None or reference_std is None:
+            raise ValueError("For t-test, both 'treatment_std' and 'reference_std' must be specified.")
+
+    return std

--- a/src/pystatpower/mean/independent/noninferiority.py
+++ b/src/pystatpower/mean/independent/noninferiority.py
@@ -1,60 +1,10 @@
-from math import ceil, sqrt
+from math import ceil
 from typing import Literal
 
 from scipy.optimize import brentq
-from scipy.stats import nct, norm, t
 
-
-def _verify_mean_and_get_diff(
-    treatment_mean: float | None,
-    reference_mean: float | None,
-    diff: float | None,
-) -> float:
-
-    if diff is None:
-        if treatment_mean is None or reference_mean is None:
-            raise ValueError("When 'diff' is omitted, both 'treatment_mean' and 'reference_mean' must be provided.")
-        diff = treatment_mean - reference_mean
-
-    return diff
-
-
-def _verify_std_and_get_std(
-    treatment_std: float | None,
-    reference_std: float | None,
-    std: float | None,
-    dist: Literal["z", "t"],
-    equal_var: bool,
-) -> float:
-
-    if dist == "z":
-        if equal_var:
-            if std is None:
-                if treatment_std is None and reference_std is None:
-                    raise ValueError(
-                        "For 'z' test with equal variance, at least one of 'std', 'treatment_std', or 'reference_std' must be specified."
-                    )
-                elif treatment_std is not None and reference_std is not None:
-                    if treatment_std != reference_std:
-                        raise ValueError(
-                            "For 'z' test with equal variance, when 'std' is omitted and both 'treatment_std' and 'reference_std' are supplied, they must be equal."
-                        )
-                    else:  # treatment_std == reference_std
-                        std = treatment_std
-                elif treatment_std is None and reference_std is not None:
-                    std = reference_std
-                else:  # treatment_std is not None and reference_std is None:
-                    std = treatment_std
-        else:  # equal_var == False
-            if treatment_std is None or reference_std is None:
-                raise ValueError(
-                    "For z-test with unequal variance, both 'treatment_std' and 'reference_std' must be specified."
-                )
-    else:  # dist == "t"
-        if treatment_std is None or reference_std is None:
-            raise ValueError("For t-test, both 'treatment_std' and 'reference_std' must be specified.")
-
-    return std
+from ._power import _power
+from ._verify import _verify_mean_and_get_diff, _verify_std_and_get_std
 
 
 def _margin(margin: float, alternative: Literal["greater", "less"]) -> float:
@@ -65,198 +15,6 @@ def _margin(margin: float, alternative: Literal["greater", "less"]) -> float:
             return -abs(margin)
         case "less":
             return abs(margin)
-
-
-def _power_z_equal_var(
-    diff: float,
-    margin: float,
-    std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a non-inferiority test of two independent means using z test with equal variance."""
-
-    se = std * sqrt(1 / treatment_size + 1 / reference_size)
-
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
-        case "less":
-            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
-
-    return float(power)
-
-
-def _power_z_unequal_var(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a non-inferiority test of two independent means using z test with unequal variance."""
-
-    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
-
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
-        case "less":
-            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
-
-    return float(power)
-
-
-def _power_t_equal_var(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a non-inferiority test of two independent means using t test with equal variance."""
-
-    df = treatment_size + reference_size - 2
-    se = sqrt(
-        ((treatment_size - 1) * treatment_std**2 + (reference_size - 1) * reference_std**2)
-        / df
-        * (1 / treatment_size + 1 / reference_size)
-    )
-    nc = (diff - margin) / se
-
-    match alternative:
-        case "greater":
-            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
-        case "less":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-
-    return power
-
-
-def _power_t_unequal_var_welch(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """
-    Calculate the statistical power for a non-inferiority test of two independent means using t test with unequal variance, degredde of freedom adjustment is based on Welch's method.
-    """
-
-    df = (treatment_std**2 / treatment_size + reference_std**2 / reference_size) ** 2 / (
-        treatment_std**4 / (treatment_size**2 * (treatment_size + 1))
-        + reference_std**4 / (reference_size**2 * (reference_size + 1))
-    ) - 2
-    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
-    nc = (diff - margin) / se
-
-    match alternative:
-        case "greater":
-            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
-        case "less":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-
-    return power
-
-
-def _power_t_unequal_var_satterthwaite(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """
-    Calculate the statistical power for a non-inferiority test of two independent means using t test with unequal variance, degree of freedom adjustment is based on Satterthwaite's method.
-    """
-
-    df = (treatment_std**2 / treatment_size + reference_std**2 / reference_size) ** 2 / (
-        treatment_std**4 / (treatment_size**2 * (treatment_size - 1))
-        + reference_std**4 / (reference_size**2 * (reference_size - 1))
-    )
-    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
-    nc = (diff - margin) / se
-
-    match alternative:
-        case "greater":
-            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
-        case "less":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-
-    return power
-
-
-def _power(
-    *,
-    diff: float | None = None,
-    margin: float,
-    treatment_std: float | None = None,
-    reference_std: float | None = None,
-    std: float | None = None,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-    dist: Literal["z", "t"],
-    equal_var: bool,
-    approx_t_method: Literal["welch", "satterthwaite"],
-) -> float:
-    """Calculate the statistical power for a non-inferiority test of two independent means."""
-
-    match dist:
-        case "z":
-            if equal_var:
-                power = _power_z_equal_var(diff, margin, std, treatment_size, reference_size, alternative, alpha)
-            else:
-                power = _power_z_unequal_var(
-                    diff, margin, treatment_std, reference_std, treatment_size, reference_size, alternative, alpha
-                )
-        case "t":
-            if equal_var:
-                power = _power_t_equal_var(
-                    diff, margin, treatment_std, reference_std, treatment_size, reference_size, alternative, alpha
-                )
-            else:
-                match approx_t_method:
-                    case "welch":
-                        power = _power_t_unequal_var_welch(
-                            diff,
-                            margin,
-                            treatment_std,
-                            reference_std,
-                            treatment_size,
-                            reference_size,
-                            alternative,
-                            alpha,
-                        )
-                    case "satterthwaite":
-                        power = _power_t_unequal_var_satterthwaite(
-                            diff,
-                            margin,
-                            treatment_std,
-                            reference_std,
-                            treatment_size,
-                            reference_size,
-                            alternative,
-                            alpha,
-                        )
-
-    return power
 
 
 def solve_power(
@@ -490,7 +248,9 @@ def solve_size(
                 - power
             )
 
-        reference_size = int(ceil(brentq(func, 3 / (1 + ratio), 1e12)))
+        lb = max(1 + 1e-12, 3 / (1 + ratio))
+        ub = 1e12
+        reference_size = int(ceil(brentq(func, lb, ub)))
         treatment_size = int(ceil(reference_size * ratio))
         return treatment_size, reference_size
     else:
@@ -514,7 +274,9 @@ def solve_size(
                 - power
             )
 
-        treatment_size = ceil(brentq(func, 3 / (1 + 1 / ratio), 1e12))
+        lb = max(1 + 1e-12, 3 / (1 + 1 / ratio))
+        ub = 1e12
+        treatment_size = ceil(brentq(func, lb, ub))
         reference_size = ceil(treatment_size / ratio)
         return treatment_size, reference_size
 

--- a/tests/test_mean/test_independent/test_noninferiority.py
+++ b/tests/test_mean/test_independent/test_noninferiority.py
@@ -6,18 +6,8 @@ from typing import Literal
 
 import pytest
 
-from pystatpower.mean.independent.noninferiority import (
-    _verify_mean_and_get_diff,
-    _verify_std_and_get_std,
-    solve_power,
-    solve_size,
-    solve_treatment_mean,
-    solve_reference_mean,
-    solve_diff,
-    solve_margin,
-    solve_treatment_std,
-    solve_reference_std,
-)
+from pystatpower.mean.independent._verify import _verify_mean_and_get_diff, _verify_std_and_get_std
+from pystatpower.mean.independent.noninferiority import solve_power, solve_size, solve_treatment_mean, solve_reference_mean, solve_diff, solve_margin, solve_treatment_std, solve_reference_std
 
 from tests.models import BaseTestCase
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Extract power functions to `_power.py`, add two-sided test support.

- Extract verification helpers to `_verify.py`.

- Refactor `noninferiority.py` to import extracted functions.

- Fix size solving lower bound to avoid invalid `brentq` interval.

- Update test imports accordingly.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["noninferiority.py"] -- "extract power functions" --> B["_power.py"]
  B -- "add two-sided test" --> B2["_power.py (enhanced)"]
  A -- "extract verify functions" --> C["_verify.py"]
  A -- "retain solve functions" --> D["noninferiority.py (updated)"]
  D -- "fix brentq lower bound" --> D2["noninferiority.py (bug fix)"]
  D -- "import from" --> E["_power.py, _verify.py"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_power.py</strong><dd><code>Add power calculation module with two-sided test support</code>&nbsp; </dd></summary>
<hr>

src/pystatpower/mean/independent/_power.py

<ul><li>Added new module with all power calculation functions for two <br>independent means.<br> <li> Added support for <code>"two-sided"</code> alternative in addition to <code>"greater"</code> and <br><code>"less"</code>.<br> <li> Includes dispatcher function <code>_power</code> for selecting test type.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/433/files#diff-822538aaae1ec2ce5893c6d1ecc715737a286dc3dd0635908da555b5149ee3e0">+210/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>noninferiority.py</strong><dd><code>Refactor noninferiority module and fix brentq bound</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/mean/independent/noninferiority.py

<ul><li>Removed all power and verification function definitions.<br> <li> Imported <code>_power</code>, <code>_verify_mean_and_get_diff</code>, <code>_verify_std_and_get_std</code> <br>from new modules.<br> <li> Fixed lower bound in <code>brentq</code> call from <code>3 / (1 + ratio)</code> to <code>max(1 + </code><br><code>1e-12, 3 / (1 + ratio))</code> to ensure positive interval.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/433/files#diff-e0a9bee20da96edc9a9808ee41907be38f378b17c55a3ca0f16889d129d5e9e2">+9/-247</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_verify.py</strong><dd><code>Extract verification helpers into new module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/mean/independent/_verify.py

<ul><li>Extracted <code>_verify_mean_and_get_diff</code> and <code>_verify_std_and_get_std</code> from <br>noninferiority.py.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/433/files#diff-e58d5d3f74d951d86b6271366f25e7ebb853b2bf4d6fcdb002aa823cf33eeb74">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_noninferiority.py</strong><dd><code>Update test imports for refactored modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_mean/test_independent/test_noninferiority.py

<ul><li>Updated import statements to reflect the new module locations for <br>verification functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/433/files#diff-6abd5e288ff67dc2e66fea263b37b06184a3840a4af3ab00f3eeb4d5e8da4f9b">+2/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

