### PR TITLE
refactor(mean.independent.superiority): remove redundant internal function, add `solve_treatment_mean`, `solve_reference_mean`

### DIFF
--- a/src/pystatpower/mean/independent/superiority.py
+++ b/src/pystatpower/mean/independent/superiority.py
@@ -56,8 +56,8 @@ def solve_power(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -76,8 +76,8 @@ def solve_power(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -169,8 +169,8 @@ def solve_size(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -187,8 +187,8 @@ def solve_size(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -309,8 +309,8 @@ def solve_treatment_mean(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -329,8 +329,8 @@ def solve_treatment_mean(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -422,8 +422,8 @@ def solve_reference_mean(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -442,8 +442,8 @@ def solve_reference_mean(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -532,8 +532,8 @@ def solve_diff(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
         reference_std:
@@ -552,8 +552,8 @@ def solve_diff(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -668,8 +668,8 @@ def solve_margin(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -775,8 +775,8 @@ def solve_treatment_std(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         reference_std:
             Standard deviation in the reference group.
 
@@ -791,8 +791,8 @@ def solve_treatment_std(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 
@@ -953,8 +953,8 @@ def solve_reference_std(
             Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
             Internally, the value of `margin` will be converted before actual calculation.
 
-            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
-            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `alternative` is `less`, the actual margin used internally is `-abs(margin)`.
         treatment_std:
             Standard deviation in the treatment group.
 
@@ -965,8 +965,8 @@ def solve_reference_std(
         alternative:
             Type of the alternative hypothesis.
 
-            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
-            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+            - If `alternative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `alternative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
         alpha:
             Significance level.
 

--- a/src/pystatpower/mean/independent/superiority.py
+++ b/src/pystatpower/mean/independent/superiority.py
@@ -1,391 +1,231 @@
-from math import ceil, sqrt
+from math import ceil
 from typing import Literal
 
 from scipy.optimize import brentq
-from scipy.stats import nct, norm, t
 
-from ..._constant import SAMPLE_SIZE_SEARCH_MAX
-
-
-def _power_z_equal_var(
-    diff: float,
-    margin: float,
-    std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a superiority test of two independent means using z-test with equal variance."""
-
-    se = std * sqrt(1 / treatment_size + 1 / reference_size)
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
-        case "less":
-            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
-    return float(power)
+from ._power import _power
+from ._verify import _verify_mean_and_get_diff, _verify_std_and_get_std
 
 
-def _power_z_unequal_var(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a superiority test of two independent means using z-test with unequal variance."""
-
-    se = sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(norm.ppf(1 - alpha) - (diff - margin) / se)
-        case "less":
-            power = norm.cdf(norm.ppf(alpha) - (diff - margin) / se)
-    return float(power)
-
-
-def _power_t_equal_var(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a superiority test of two independent means using t-test with equal variance."""
-
-    df = treatment_size + reference_size - 2
-    var_c = ((treatment_size - 1) * treatment_std**2 + (reference_size - 1) * reference_std**2) / df
-    nc = (diff - margin) / sqrt(var_c * (1 / treatment_size + 1 / reference_size))
+def _margin(margin: float, alternative: Literal["greater", "less"]) -> float:
+    """Convert margin to standard form based on alternative hypothesis"""
 
     match alternative:
         case "greater":
-            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
+            return abs(margin)
         case "less":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-
-    return power
-
-
-def _power_unequal_var_welch(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """
-    Calculate the statistical power for a superiority test of two independent means using t-test with unequal variance,
-    degree of freedom adjustment is based on Welch's method.
-    """
-
-    df = (treatment_std**2 / treatment_size + reference_std**2 / reference_size) ** 2 / (
-        treatment_std**4 / (treatment_size**2 * (treatment_size + 1))
-        + reference_std**4 / (reference_size**2 * (reference_size + 1))
-    ) - 2
-    nc = (diff - margin) / sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
-
-    match alternative:
-        case "greater":
-            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
-        case "less":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-
-    return power
-
-
-def _power_unequal_var_satterthwaite(
-    diff: float,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """
-    Calculate the statistical power for a superiority test of two independent means using t-test with unequal variance,
-    degree of freedom adjustment is based on Satterthwaite's method.
-    """
-
-    df = (treatment_std**2 / treatment_size + reference_std**2 / reference_size) ** 2 / (
-        treatment_std**4 / (treatment_size**2 * (treatment_size - 1))
-        + reference_std**4 / (reference_size**2 * (reference_size - 1))
-    )
-    nc = (diff - margin) / sqrt(treatment_std**2 / treatment_size + reference_std**2 / reference_size)
-
-    match alternative:
-        case "greater":
-            power = 1 - nct.cdf(t.ppf(1 - alpha, df), df, nc)
-        case "less":
-            power = nct.cdf(t.ppf(alpha, df), df, nc)
-
-    return power
-
-
-def _power(
-    *,
-    diff: float | None = None,
-    treatment_mean: float | None = None,
-    reference_mean: float | None = None,
-    margin: float,
-    treatment_std: float,
-    reference_std: float,
-    treatment_size: float,
-    reference_size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-    method: Literal["z", "t"],
-    equal_var: bool,
-    df_adjust: Literal["welch", "satterthwaite"],
-) -> float:
-    """Calculate the statistical power for a superiority test of two independent means."""
-
-    if diff is None:
-        if treatment_mean is None or reference_mean is None:
-            raise ValueError("If 'diff' is not provided, both 'treatment_mean' and 'reference_mean' must be specified.")
-        diff = treatment_mean - reference_mean
-
-    match method:
-        case "z":
-            if equal_var:
-                assert treatment_std == reference_std
-                std = treatment_std
-                power = _power_z_equal_var(diff, margin, std, treatment_size, reference_size, alternative, alpha)
-            else:
-                power = _power_z_unequal_var(
-                    diff, margin, treatment_std, reference_std, treatment_size, reference_size, alternative, alpha
-                )
-        case "t":
-            if equal_var:
-                power = _power_t_equal_var(
-                    diff, margin, treatment_std, reference_std, treatment_size, reference_size, alternative, alpha
-                )
-            else:
-                match df_adjust:
-                    case "welch":
-                        power = _power_unequal_var_welch(
-                            diff,
-                            margin,
-                            treatment_std,
-                            reference_std,
-                            treatment_size,
-                            reference_size,
-                            alternative,
-                            alpha,
-                        )
-                    case "satterthwaite":
-                        power = _power_unequal_var_satterthwaite(
-                            diff,
-                            margin,
-                            treatment_std,
-                            reference_std,
-                            treatment_size,
-                            reference_size,
-                            alternative,
-                            alpha,
-                        )
-
-    return power
+            return -abs(margin)
 
 
 def solve_power(
     *,
-    diff: float | None = None,
     treatment_mean: float | None = None,
     reference_mean: float | None = None,
+    diff: float | None = None,
     margin: float,
-    treatment_std: float,
-    reference_std: float,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
-    method: Literal["z", "t"] = "t",
+    dist: Literal["z", "t"] = "t",
     equal_var: bool = False,
-    df_adjust: Literal["welch", "satterthwaite"] = "welch",
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
 ) -> float:
     """
     Calculate the statistical power for a superiority test of two independent means.
 
     Args:
-        diff (float, optional):
-            Mean difference between treatment and reference group ($\\mu_1 - \\mu_2$).
+        treatment_mean:
+            Mean in the treatment group.
 
-            If provided, `treatment_mean` and `reference_mean` will be ignored.
-        treatment_mean (float, optional):
-            Mean in the treatment group ($\\mu_1$).
+            If `diff` is not specified, this parameter must be specified along with `reference_mean`.
+        reference_mean:
+            Mean in the reference group.
 
-            If `diff` is not provided, this must be specified along with `reference_mean`.
-        reference_mean (float, optional):
-            Mean in the reference group ($\\mu_2$).
+            If `diff` is not specified, this parameter must be specified along with `treatment_mean`.
+        diff:
+            Mean difference between treatment and reference group.
 
-            If `diff` is not provided, this must be specified along with `treatment_mean`.
-        margin (float):
-            The superiority margin ($\\delta$)
+            If both `treatment_mean` and `reference_mean` are not specified, this parameter must be specified.
+        margin:
+            The superiority margin.
 
-            - provide a positive value if a higher mean is better
-            - provide a negative value if a higher mean is worse
-        treatment_std (float):
-            Standard deviation in the treatment group ($\\sigma_1$).
-        reference_std (float):
-            Standard deviation in the reference group ($\\sigma_2$).
-        treatment_size (int):
-            Sample size in the treatment group ($n_1$).
-        reference_size (int):
-            Sample size in the reference group ($n_2$).
-        alternative (Literal["greater", "less"]):
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        treatment_std:
+            Standard deviation in the treatment group.
+        reference_std:
+            Standard deviation in the reference group.
+        std:
+            Standard deviation in both groups.
+
+            This is a convenience parameter that will override `treatment_std` and `reference_std` when `dist` is `z` and `equal_var` is `True`.
+
+            If you specify `dist` as `z` and `equal_var` as `True`, you can just specify `std` instead of `treatment_std` and `reference_std`.
+            Internally, the value of `std` will be treated as the standard deviation of both the treatment and reference groups.
+        treatment_size:
+            Sample size for the treatment group.
+        reference_size:
+            Sample size for the reference group.
+        alternative:
             Type of the alternative hypothesis.
 
-            - `'greater'`: upper-tailed alternative hypothesis: $\\mu_1 - \\mu_2 > \\delta$
-            - `'less'`: lower-tailed alternative hypothesis: $\\mu_1 - \\mu_2 < \\delta$
-        alpha (float, optional):
-            One-sided significance level.
-        method (Literal["z", "t"], optional):
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        dist:
             The distribution used for the test.
 
-            - `'z'`: Standard normal distribution (large sample approximation).
-            - `'t'`: Student's or non-central *t* distribution.
+            - `'z'`: Standard normal distribution.
+            - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
 
-        equal_var (bool, optional):
-            Whether to assume equal variances between groups.
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
 
-            - `True`: Assume $\\sigma_1^2 = \\sigma_2^2$. Use *Pooled Variance* to calculate SE.
-              If `method='t'`, the degree of freedom $df = n_1 + n_2 - 2$.
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
 
-            - `False`: Assume $\\sigma_1^2 \\neq \\sigma_2^2$. Use *Unpooled Variance* to calculate SE.
-              If `method='t'`, the degree of freedom is adjusted based on the `df_adjust` parameter.
-
-            If `method='z'` and `equal_var=True`, the standard deviation of the two groups must be equal.
-        df_adjust (Literal["welch", "satterthwaite"], optional):
-            Degree of freedom adjustment method when `method="t"` and `equal_var=False`.
-
-            - `'welch'`: Adjustment based on Welch (1947).
-            - `'satterthwaite'`: Adjustment based on Satterthwaite (1946).
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
 
     Returns:
-        (float): The calculated statistical power of the test.
+        float: The statistical power of the test.
 
     Raises:
-        ValueError: If `diff` is not provided, and either `treatment_mean` or `reference_mean` is not provided.
-        ValueError: If `method='z'` and `equal_var=True` but `treatment_std` does not equal to `reference_std`.
+        ValueError: If `diff` is not specified, and neither `treatment_mean` nor `reference_mean` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True`, and any of `treatment_std`, `reference_std` or `std` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True` without specifying `std`: `treatment_std` and `reference_std` are not equal if both are provided.
     """
 
-    if method == "z" and equal_var and treatment_std != reference_std:
-        raise ValueError("If method='z' and equal_var=True, treatment_std must equal reference_std.")
+    diff = _verify_mean_and_get_diff(treatment_mean, reference_mean, diff)
+    std = _verify_std_and_get_std(treatment_std, reference_std, std, dist, equal_var)
+
+    margin = _margin(margin, alternative)
 
     power = _power(
         diff=diff,
-        treatment_mean=treatment_mean,
-        reference_mean=reference_mean,
         margin=margin,
         treatment_std=treatment_std,
         reference_std=reference_std,
+        std=std,
         treatment_size=treatment_size,
         reference_size=reference_size,
         alternative=alternative,
         alpha=alpha,
-        method=method,
+        dist=dist,
         equal_var=equal_var,
-        df_adjust=df_adjust,
+        approx_t_method=approx_t_method,
     )
     return power
 
 
 def solve_size(
     *,
-    diff: float | None = None,
     treatment_mean: float | None = None,
     reference_mean: float | None = None,
+    diff: float | None = None,
     margin: float,
-    treatment_std: float,
-    reference_std: float,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
     ratio: float = 1,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
-    method: Literal["z", "t"] = "t",
+    dist: Literal["z", "t"] = "t",
     equal_var: bool = False,
-    df_adjust: Literal["welch", "satterthwaite"] = "welch",
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
 ) -> tuple[int, int]:
     """
     Estimate the required sample size for a superiority test of two independent means.
 
     Args:
-        diff (float, optional):
-            Mean difference between treatment and reference group ($\\mu_1 - \\mu_2$).
+        treatment_mean:
+            Mean in the treatment group.
 
-            If provided, `treatment_mean` and `reference_mean` will be ignored.
-        treatment_mean (float, optional):
-            Mean in the treatment group ($\\mu_1$).
+            If `diff` is not specified, this parameter must be specified along with `reference_mean`.
+        reference_mean:
+            Mean in the reference group.
 
-            If `diff` is not provided, this must be specified along with `reference_mean`.
-        reference_mean (float, optional):
-            Mean in the reference group ($\\mu_2$).
+            If `diff` is not specified, this parameter must be specified along with `treatment_mean`.
+        diff:
+            Mean difference between treatment and reference group.
 
-            If `diff` is not provided, this must be specified along with `treatment_mean`.
-        margin (float):
-            The superiority margin ($\\delta$)
+            If both `treatment_mean` and `reference_mean` are not specified, this parameter must be specified.
+        margin:
+            The superiority margin.
 
-            - provide a positive value if a higher mean is better
-            - provide a negative value if a higher mean is worse
-        treatment_std (float):
-            Standard deviation in the treatment group ($\\sigma_1$).
-        reference_std (float):
-            Standard deviation in the reference group ($\\sigma_2$).
-        ratio (float, optional):
-            Ratio of treatment sample size to reference sample size ($k = n_1 / n_2$).
-        alternative (Literal["greater", "less"]):
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        treatment_std:
+            Standard deviation in the treatment group.
+        reference_std:
+            Standard deviation in the reference group.
+        std:
+            Standard deviation in both groups.
+
+            This is a convenience parameter that will override `treatment_std` and `reference_std` when `dist` is `z` and `equal_var` is `True`.
+
+            If you specify `dist` as `z` and `equal_var` as `True`, you can just specify `std` instead of `treatment_std` and `reference_std`.
+            Internally, the value of `std` will be treated as the standard deviation of both the treatment and reference groups.
+        ratio:
+            Ratio of sample size in the treatment and reference group.
+        alternative:
             Type of the alternative hypothesis.
 
-            - `'greater'`: upper-tailed alternative hypothesis: $\\mu_1 - \\mu_2 > \\delta$
-            - `'less'`: lower-tailed alternative hypothesis: $\\mu_1 - \\mu_2 < \\delta$
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Desired statistical power.
-        method (Literal["z", "t"], optional):
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
             The distribution used for the test.
 
-            - `'z'`: Standard normal distribution (large sample approximation).
-            - `'t'`: Student's or non-central *t* distribution.
+            - `'z'`: Standard normal distribution.
+            - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
 
-        equal_var (bool, optional):
-            Whether to assume equal variances between groups.
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
 
-            - `True`: Assume $\\sigma_1^2 = \\sigma_2^2$. Use *Pooled Variance* to calculate SE.
-              If `method="t"`, degree of freedom $df = n_1 + n_2 - 2$.
-
-            - `False`: Assume $\\sigma_1^2 \\neq \\sigma_2^2$. Use *Unpooled Variance* to calculate SE.
-              If `method="t"`, the degree of freedom is adjusted based on the `df_adjust` parameter.
-
-            If `method='z'` and `equal_var=True`, the standard deviation of the two groups must be equal.
-        df_adjust (Literal["welch", "satterthwaite"], optional):
-            Degree of freedom adjustment method when `method="t"` and `equal_var=False`.
-
-            - `'welch'`: Adjustment based on Welch (1947).
-            - `'satterthwaite'`: Adjustment based on Satterthwaite (1946).
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
 
     Returns:
-        (tuple[int, int]): The required sample sizes for the treatment and reference groups, respectively.
+        tuple[int, int]: The required sample sizes for the treatment and reference groups, respectively.
 
     Raises:
-        ValueError: If `diff` is not provided, and either `treatment_mean` or `reference_mean` is not provided.
-        ValueError: If `method='z'` and `equal_var=True` but `treatment_std` does not equal to `reference_std`.
+        ValueError: If `diff` is not specified, and neither `treatment_mean` nor `reference_mean` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True`, and any of `treatment_std`, `reference_std` or `std` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True` without specifying `std`: `treatment_std` and `reference_std` are not equal if both are provided.
     """
 
-    if method == "z" and equal_var and treatment_std != reference_std:
-        raise ValueError("If method='z' and equal_var=True, treatment_std must equal reference_std.")
+    diff = _verify_mean_and_get_diff(treatment_mean, reference_mean, diff)
+    std = _verify_std_and_get_std(treatment_std, reference_std, std, dist, equal_var)
+
+    margin = _margin(margin, alternative)
 
     if ratio >= 1:
 
@@ -393,25 +233,24 @@ def solve_size(
             return (
                 _power(
                     diff=diff,
-                    treatment_mean=treatment_mean,
-                    reference_mean=reference_mean,
                     margin=margin,
                     treatment_std=treatment_std,
                     reference_std=reference_std,
+                    std=std,
                     treatment_size=reference_size * ratio,
                     reference_size=reference_size,
                     alternative=alternative,
                     alpha=alpha,
-                    method=method,
+                    dist=dist,
                     equal_var=equal_var,
-                    df_adjust=df_adjust,
+                    approx_t_method=approx_t_method,
                 )
                 - power
             )
 
-        lower_bound = max(3 / (1 + ratio), 1) + 0.000001
-        upper_bound = SAMPLE_SIZE_SEARCH_MAX
-        reference_size = int(ceil(brentq(func, lower_bound, upper_bound)))
+        lb = max(1 + 1e-12, 3 / (1 + ratio))
+        ub = 1e12
+        reference_size = int(ceil(brentq(func, lb, ub)))
         treatment_size = int(ceil(reference_size * ratio))
         return treatment_size, reference_size
     else:
@@ -420,111 +259,337 @@ def solve_size(
             return (
                 _power(
                     diff=diff,
-                    treatment_mean=treatment_mean,
-                    reference_mean=reference_mean,
                     margin=margin,
                     treatment_std=treatment_std,
                     reference_std=reference_std,
+                    std=std,
                     treatment_size=treatment_size,
                     reference_size=treatment_size / ratio,
                     alternative=alternative,
                     alpha=alpha,
-                    method=method,
+                    dist=dist,
                     equal_var=equal_var,
-                    df_adjust=df_adjust,
+                    approx_t_method=approx_t_method,
                 )
                 - power
             )
 
-        lower_bound = max(3 / (1 + 1 / ratio), 1) + 0.000001
-        upper_bound = SAMPLE_SIZE_SEARCH_MAX
-        treatment_size = ceil(brentq(func, lower_bound, upper_bound))
+        lb = max(1 + 1e-12, 3 / (1 + 1 / ratio))
+        ub = 1e12
+        treatment_size = ceil(brentq(func, lb, ub))
         reference_size = ceil(treatment_size / ratio)
         return treatment_size, reference_size
 
 
-def solve_diff(
+def solve_treatment_mean(
     *,
+    reference_mean: float,
     margin: float,
-    treatment_std: float,
-    reference_std: float,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
-    method: Literal["z", "t"] = "t",
+    dist: Literal["z", "t"] = "t",
     equal_var: bool = False,
-    df_adjust: Literal["welch", "satterthwaite"] = "welch",
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
 ) -> float:
     """
-    Estimate the required difference for a superiority test of two independent means.
+    Estimate the required mean in the treatment group for a superiority test of two independent means.
 
     Args:
-        margin (float):
-            The superiority margin ($\\delta$)
+        reference_mean:
+            Mean in the reference group.
+        margin:
+            The superiority margin.
 
-            - provide a positive value if a higher mean is better
-            - provide a negative value if a higher mean is worse
-        treatment_std (float):
-            Standard deviation in the treatment group ($\\sigma_1$).
-        reference_std (float):
-            Standard deviation in the reference group ($\\sigma_2$).
-        treatment_size (int):
-            Sample size for the treatment group ($n_1$).
-        reference_size (int):
-            Sample size for the reference group ($n_2$).
-        alternative (Literal["greater", "less"]):
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        treatment_std:
+            Standard deviation in the treatment group.
+        reference_std:
+            Standard deviation in the reference group.
+        std:
+            Standard deviation in both groups.
+
+            This is a convenience parameter that will override `treatment_std` and `reference_std` when `dist` is `z` and `equal_var` is `True`.
+
+            If you specify `dist` as `z` and `equal_var` as `True`, you can just specify `std` instead of `treatment_std` and `reference_std`.
+            Internally, the value of `std` will be treated as the standard deviation of both the treatment and reference groups.
+        treatment_size:
+            Sample size for the treatment group.
+        reference_size:
+            Sample size for the reference group.
+        alternative:
             Type of the alternative hypothesis.
 
-            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
-            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Desired statistical power.
-        method (Literal["z", "t"], optional):
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
             The distribution used for the test.
 
-            - `'z'`: Standard normal distribution (large sample approximation).
-            - `'t'`: Student's or non-central *t* distribution.
+            - `'z'`: Standard normal distribution.
+            - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
 
-        equal_var (bool, optional):
-            Whether to assume equal variances between groups.
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
 
-            - `True`: Assume $\\sigma_1^2 = \\sigma_2^2$. Use *Pooled Variance* to calculate SE.
-              If `method='t'`, degree of freedom $df = n_1 + n_2 - 2$.
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
 
-            - `False`: Assume $\\sigma_1^2 \\neq \\sigma_2^2$. Use *Unpooled Variance* to calculate SE.
-              If `method='t'`, the degree of freedom is adjusted based on the `df_adjust` parameter.
-
-            If `method='z'` and `equal_var=True`, the standard deviation of the two groups must be equal.
-        df_adjust (Literal["welch", "satterthwaite"], optional):
-            Degree of freedom adjustment method when `method='t'` and `equal_var=False`.
-
-            - `'welch'`: Adjustment based on Welch (1947).
-            - `'satterthwaite'`: Adjustment based on Satterthwaite (1946).
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
 
     Returns:
-        (float): The required difference between the treatment and reference means.
+        float: The required mean in the treatment group.
 
     Raises:
-        ValueError: If `method='z'` and `equal_var=True` but `treatment_std` does not equal to `reference_std`.
-
-    Notes:
-        The search interval for mean difference ($\\mu_1 - \\mu_2$) is constrained by the superiority margin ($\\delta$) to ensure the alternative hypothesis remains plausible.
-
-        $$
-        \\text{Search Interval} =
-        \\begin{cases}
-        (\\delta, \\ +\\infty)  & , \\text{if alternative is upper} \\\\
-        (-\\infty, \\ \\delta)  & , \\text{if alternative is lower} \\\\
-        \\end{cases}
-        $$
+        ValueError: If `dist` is `z` and `equal_var` is `True`, and any of `treatment_std`, `reference_std` or `std` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True` without specifying `std`: `treatment_std` and `reference_std` are not equal if both are provided.
     """
 
-    if method == "z" and equal_var and treatment_std != reference_std:
-        raise ValueError("If method='z' and equal_var=True, treatment_std must equal reference_std.")
+    std = _verify_std_and_get_std(treatment_std, reference_std, std, dist, equal_var)
+
+    margin = _margin(margin, alternative)
+
+    def func(treatment_mean: float) -> float:
+        return (
+            _power(
+                diff=treatment_mean - reference_mean,
+                margin=margin,
+                treatment_std=treatment_std,
+                reference_std=reference_std,
+                std=std,
+                treatment_size=treatment_size,
+                reference_size=reference_size,
+                alternative=alternative,
+                alpha=alpha,
+                dist=dist,
+                equal_var=equal_var,
+                approx_t_method=approx_t_method,
+            )
+            - power
+        )
+
+    match alternative:
+        case "greater":
+            return float(brentq(func, reference_mean + margin, 1e9))
+        case "less":
+            return float(brentq(func, -1e9, reference_mean + margin))
+
+
+def solve_reference_mean(
+    *,
+    treatment_mean: float,
+    margin: float,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
+    treatment_size: int,
+    reference_size: int,
+    alternative: Literal["greater", "less"],
+    alpha: float = 0.025,
+    power: float = 0.80,
+    dist: Literal["z", "t"] = "t",
+    equal_var: bool = False,
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
+) -> float:
+    """
+    Estimate the required mean in the reference group for a superiority test of two independent means.
+
+    Args:
+        treatment_mean:
+            Mean in the treatment group.
+        margin:
+            The superiority margin.
+
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        treatment_std:
+            Standard deviation in the treatment group.
+        reference_std:
+            Standard deviation in the reference group.
+        std:
+            Standard deviation in both groups.
+
+            This is a convenience parameter that will override `treatment_std` and `reference_std` when `dist` is `z` and `equal_var` is `True`.
+
+            If you specify `dist` as `z` and `equal_var` as `True`, you can just specify `std` instead of `treatment_std` and `reference_std`.
+            Internally, the value of `std` will be treated as the standard deviation of both the treatment and reference groups.
+        treatment_size:
+            Sample size for the treatment group.
+        reference_size:
+            Sample size for the reference group.
+        alternative:
+            Type of the alternative hypothesis.
+
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
+            The distribution used for the test.
+
+            - `'z'`: Standard normal distribution.
+            - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
+
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
+
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
+
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
+
+    Returns:
+        float: The required mean in the reference group.
+
+    Raises:
+        ValueError: If `dist` is `z` and `equal_var` is `True`, and any of `treatment_std`, `reference_std` or `std` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True` without specifying `std`: `treatment_std` and `reference_std` are not equal if both are provided.
+    """
+
+    std = _verify_std_and_get_std(treatment_std, reference_std, std, dist, equal_var)
+
+    margin = _margin(margin, alternative)
+
+    def func(reference_mean: float) -> float:
+        return (
+            _power(
+                diff=treatment_mean - reference_mean,
+                margin=margin,
+                treatment_std=treatment_std,
+                reference_std=reference_std,
+                std=std,
+                treatment_size=treatment_size,
+                reference_size=reference_size,
+                alternative=alternative,
+                alpha=alpha,
+                dist=dist,
+                equal_var=equal_var,
+                approx_t_method=approx_t_method,
+            )
+            - power
+        )
+
+    match alternative:
+        case "greater":
+            return float(brentq(func, -1e9, treatment_mean - margin))
+        case "less":
+            return float(brentq(func, treatment_mean - margin, 1e9))
+
+
+def solve_diff(
+    *,
+    margin: float,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
+    treatment_size: int,
+    reference_size: int,
+    alternative: Literal["greater", "less"],
+    alpha: float = 0.025,
+    power: float = 0.80,
+    dist: Literal["z", "t"] = "t",
+    equal_var: bool = False,
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
+) -> float:
+    """
+    Estimate the required difference between the mean in treatment and reference groups for a superiority test of two independent means.
+
+    Args:
+        margin:
+            The superiority margin.
+
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        treatment_std:
+            Standard deviation in the treatment group.
+        reference_std:
+            Standard deviation in the reference group.
+        std:
+            Standard deviation in both groups.
+
+            This is a convenience parameter that will override `treatment_std` and `reference_std` when `dist` is `z` and `equal_var` is `True`.
+
+            If you specify `dist` as `z` and `equal_var` as `True`, you can just specify `std` instead of `treatment_std` and `reference_std`.
+            Internally, the value of `std` will be treated as the standard deviation of both the treatment and reference groups.
+        treatment_size:
+            Sample size for the treatment group.
+        reference_size:
+            Sample size for the reference group.
+        alternative:
+            Type of the alternative hypothesis.
+
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
+            The distribution used for the test.
+
+            - `'z'`: Standard normal distribution.
+            - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
+
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
+
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
+
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
+
+    Returns:
+        float: The required difference between the mean in treatment and reference groups.
+
+    Raises:
+        ValueError: If `dist` is `z` and `equal_var` is `True`, and any of `treatment_std`, `reference_std` or `std` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True` without specifying `std`: `treatment_std` and `reference_std` are not equal if both are provided.
+    """
+
+    std = _verify_std_and_get_std(treatment_std, reference_std, std, dist, equal_var)
+
+    margin = _margin(margin, alternative)
 
     def func(diff: float) -> float:
         return (
@@ -533,106 +598,118 @@ def solve_diff(
                 margin=margin,
                 treatment_std=treatment_std,
                 reference_std=reference_std,
+                std=std,
                 treatment_size=treatment_size,
                 reference_size=reference_size,
                 alternative=alternative,
                 alpha=alpha,
-                method=method,
+                dist=dist,
                 equal_var=equal_var,
-                df_adjust=df_adjust,
+                approx_t_method=approx_t_method,
             )
             - power
         )
 
-    DIFF_SEARCH_MIN = -1000000
-    DIFF_SEARCH_MAX = 1000000
-
     match alternative:
-        case "less":
-            return float(brentq(func, DIFF_SEARCH_MIN, margin))
         case "greater":
-            return float(brentq(func, margin, DIFF_SEARCH_MAX))
+            return float(brentq(func, margin, 1e9))
+        case "less":
+            return float(brentq(func, -1e9, margin))
 
 
 def solve_margin(
     *,
-    diff: float,
-    treatment_std: float,
-    reference_std: float,
+    treatment_mean: float | None = None,
+    reference_mean: float | None = None,
+    diff: float | None = None,
+    treatment_std: float | None = None,
+    reference_std: float | None = None,
+    std: float | None = None,
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
-    method: Literal["z", "t"] = "t",
+    dist: Literal["z", "t"] = "t",
     equal_var: bool = False,
-    df_adjust: Literal["welch", "satterthwaite"] = "welch",
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
 ) -> float:
     """
     Estimate the required margin for a superiority test of two independent means.
 
     Args:
-        diff (float):
-            Mean difference between treatment and reference group ($\\mu_1 - \\mu_2$).
-        treatment_std (float):
-            Standard deviation in the treatment group ($\\sigma_1$).
-        reference_std (float):
-            Standard deviation in the reference group ($\\sigma_2$).
-        treatment_size (int):
-            Sample size for the treatment group ($n_1$).
-        reference_size (int):
-            Sample size for the reference group ($n_2$).
-        alternative (Literal["greater", "less"]):
+        treatment_mean:
+            Mean in the treatment group.
+
+            If `diff` is not specified, this parameter must be specified along with `reference_mean`.
+        reference_mean:
+            Mean in the reference group.
+
+            If `diff` is not specified, this parameter must be specified along with `treatment_mean`.
+        diff:
+            Mean difference between treatment and reference group.
+
+            If both `treatment_mean` and `reference_mean` are not specified, this parameter must be specified.
+        treatment_std:
+            Standard deviation in the treatment group.
+        reference_std:
+            Standard deviation in the reference group.
+        std:
+            Standard deviation in both groups.
+
+            This is a convenience parameter that will override `treatment_std` and `reference_std` when `dist` is `z` and `equal_var` is `True`.
+
+            If you specify `dist` as `z` and `equal_var` as `True`, you can just specify `std` instead of `treatment_std` and `reference_std`.
+            Internally, the value of `std` will be treated as the standard deviation of both the treatment and reference groups.
+        treatment_size:
+            Sample size for the treatment group.
+        reference_size:
+            Sample size for the reference group.
+        alternative:
             Type of the alternative hypothesis.
 
-            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
-            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Desired statistical power.
-        method (Literal["z", "t"], optional):
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
             The distribution used for the test.
 
-            - `'z'`: Standard normal distribution (large sample approximation).
+            - `'z'`: Standard normal distribution.
             - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
 
-        equal_var (bool, optional):
-            Whether to assume equal variances between groups.
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
 
-            - `True`: Assume $\\sigma_1^2 = \\sigma_2^2$. Use *Pooled Variance* to calculate SE.
-              If `method='t'`, degree of freedom $df = n_1 + n_2 - 2$.
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
 
-            - `False`: Assume $\\sigma_1^2 \\neq \\sigma_2^2$. Use *Unpooled Variance* to calculate SE.
-              If `method='t'`, the degree of freedom is adjusted based on the `df_adjust` parameter.
-
-            If `method='z'` and `equal_var=True`, the standard deviation of the two groups must be equal.
-        df_adjust (Literal["welch", "satterthwaite"], optional):
-            Degree of freedom adjustment method when `method='t'` and `equal_var=False`.
-
-            - `'welch'`: Adjustment based on Welch (1947).
-            - `'satterthwaite'`: Adjustment based on Satterthwaite (1946).
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
 
     Returns:
-        (float): The required superiority margin.
+        float:
+            The required superiority margin for the test.
+
+            - If `alternative` is `greater`, the returned value is in the range $[0, \\hat{\\mu}_1 - \\hat{\\mu}_2)$
+            - If `alternative` is `less`, the returned value is in the range $(\\hat{\\mu}_1 - \\hat{\\mu}_2, 0]$
 
     Raises:
-        ValueError: If `method='z'` and `equal_var=True` but `treatment_std` does not equal to `reference_std`.
-
-    Notes:
-        The search interval for superiority margin ($\\delta$) is constrained by the mean difference ($\\mu_1 - \\mu_2$) to ensure the alternative hypothesis remains plausible.
-
-        $$
-        \\text{Search Interval} =
-        \\begin{cases}
-        [0, \\ \\mu_1 - \\mu_2) & , \\text{if alternative is upper} \\\\
-        (\\mu_1 - \\mu_2, \\ 0] & , \\text{if alternative is lower} \\\\
-        \\end{cases}
-        $$
+        ValueError: If `diff` is not specified, and neither `treatment_mean` nor `reference_mean` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True`, and any of `treatment_std`, `reference_std` or `std` is not specified.
+        ValueError: If `dist` is `z` and `equal_var` is `True` without specifying `std`: `treatment_std` and `reference_std` are not equal if both are provided.
     """
 
-    if method == "z" and equal_var and treatment_std != reference_std:
-        raise ValueError("If method='z' and equal_var=True, treatment_std must equal reference_std.")
+    diff = _verify_mean_and_get_diff(treatment_mean, reference_mean, diff)
+    std = _verify_std_and_get_std(treatment_std, reference_std, std, dist, equal_var)
 
     def func(margin: float) -> float:
         return (
@@ -641,140 +718,186 @@ def solve_margin(
                 margin=margin,
                 treatment_std=treatment_std,
                 reference_std=reference_std,
+                std=std,
                 treatment_size=treatment_size,
                 reference_size=reference_size,
                 alternative=alternative,
                 alpha=alpha,
-                method=method,
+                dist=dist,
                 equal_var=equal_var,
-                df_adjust=df_adjust,
+                approx_t_method=approx_t_method,
             )
             - power
         )
 
     match alternative:
         case "greater":
-            return brentq(func, -0.000001, diff)
+            return float(brentq(func, -1e9, diff))
         case "less":
-            return brentq(func, diff, 0.000001)
+            return float(brentq(func, diff, 1e9))
 
 
 def solve_treatment_std(
     *,
-    diff: float | None = None,
     treatment_mean: float | None = None,
     reference_mean: float | None = None,
+    diff: float | None = None,
     margin: float,
+    reference_std: float | None = None,
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
-    method: Literal["z", "t"] = "t",
+    dist: Literal["z", "t"] = "t",
     equal_var: bool = True,
-    reference_std: float | None = None,
-    df_adjust: Literal["welch", "satterthwaite"] = "welch",
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
 ) -> float:
     """
     Estimate the required standard deviation in the treatment group for a superiority test of two independent means.
 
     Args:
-        diff (float, optional):
-            Mean difference between treatment and reference group ($\\mu_1 - \\mu_2$).
+        treatment_mean:
+            Mean in the treatment group.
 
-            If provided, `treatment_mean` and `reference_mean` will be ignored.
-        treatment_mean (float, optional):
-            Mean in the treatment group ($\\mu_1$).
+            If `diff` is not specified, this parameter must be specified along with `reference_mean`.
+        reference_mean:
+            Mean in the reference group.
 
-            If `diff` is not provided, this must be specified along with `reference_mean`.
-        reference_mean (float, optional):
-            Mean in the reference group ($\\mu_2$).
+            If `diff` is not specified, this parameter must be specified along with `treatment_mean`.
+        diff:
+            Mean difference between treatment and reference group.
 
-            If `diff` is not provided, this must be specified along with `treatment_mean`.
-        margin (float):
-            The superiority margin ($\\delta$)
+            If both `treatment_mean` and `reference_mean` are not specified, this parameter must be specified.
+        margin:
+            The superiority margin.
 
-            - provide a positive value if a higher mean is better
-            - provide a negative value if a higher mean is worse
-        treatment_size (int):
-            Sample size for the treatment group ($n_1$).
-        reference_size (int):
-            Sample size for the reference group ($n_2$).
-        alternative (Literal["greater", "less"]):
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        reference_std:
+            Standard deviation in the reference group.
+
+            - If `dist` is `z` and `equal_var` is `True`, this parameter is ignored.
+            - If `dist` is `z` and `equal_var` is `False`, this parameter is required.
+            - If `dist` is `t` and `equal_var` is `True`, this parameter is optional. If specified, this value is used to calculate the standard error of mean difference.
+            - If `dist` is `t` and `equal_var` is `False`, this parameter is required.
+        treatment_size:
+            Sample size for the treatment group.
+        reference_size:
+            Sample size for the reference group.
+        alternative:
             Type of the alternative hypothesis.
 
-            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Desired statistical power.
-        method (Literal["z", "t"], optional):
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
             The distribution used for the test.
 
-            - `'z'`: Standard normal distribution (large sample approximation).
+            - `'z'`: Standard normal distribution.
             - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
 
-        equal_var (bool, optional):
-            Whether to assume equal variances between groups.
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
 
-            - `True`: Assume $\\sigma_1^2 = \\sigma_2^2$. Use *Pooled Variance* to calculate SE.
-              If `method='t'`, degree of freedom $df = n_1 + n_2 - 2$.
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
 
-            - `False`: Assume $\\sigma_1^2 \\neq \\sigma_2^2$. Use *Unpooled Variance* to calculate SE.
-              If `method='t'`, the degree of freedom is adjusted based on the `df_adjust` parameter.
-
-            If Z test is used and `equal_var` is True, the standard deviation of the two groups must be equal.
-        reference_std (float | None, optional):
-            Standard deviation in the reference group ($\\sigma_2$).
-
-            If `equal_var=True`, this parameter is ignored, otherwise, you must specify this parameter.
-        df_adjust (Literal["welch", "satterthwaite"], optional):
-            Degree of freedom adjustment method when `method='t'` and `equal_var=False`.
-
-            - `'welch'`: Adjustment based on Welch (1947).
-            - `'satterthwaite'`: Adjustment based on Satterthwaite (1946).
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
 
     Returns:
-        (float): The required standard deviation in the treatment group.
+        float: The required standard deviation in the treatment group.
 
     Raises:
-        ValueError: If `diff` is not provided, and either `treatment_mean` or `reference_mean` is not provided.
-        ValueError: If `equal_var=False` and `reference_std=None`.
+        ValueError: If `diff` is not specified, and neither `treatment_mean` nor `reference_mean` is not specified.
+        ValueError: If `equal_var` is `False`, and `reference_std` is not specified.
     """
 
+    diff = _verify_mean_and_get_diff(treatment_mean, reference_mean, diff)
+
     if not equal_var and reference_std is None:
-        raise ValueError("reference_std must be provided when equal_var=False.")
+        raise ValueError("'reference_std' must be specified when 'equal_var' = False.")
+
+    margin = _margin(margin, alternative)
 
     if equal_var:
+        match dist:
+            case "z":
 
-        def func(treatment_std: float) -> float:
-            return (
-                _power(
-                    diff=diff,
-                    treatment_mean=treatment_mean,
-                    reference_mean=reference_mean,
-                    margin=margin,
-                    treatment_std=treatment_std,
-                    reference_std=treatment_std,
-                    treatment_size=treatment_size,
-                    reference_size=reference_size,
-                    alternative=alternative,
-                    alpha=alpha,
-                    method=method,
-                    equal_var=equal_var,
-                    df_adjust=df_adjust,
-                )
-                - power
-            )
+                def func(treatment_std: float) -> float:
+                    return (
+                        _power(
+                            diff=diff,
+                            margin=margin,
+                            std=treatment_std,
+                            treatment_size=treatment_size,
+                            reference_size=reference_size,
+                            alternative=alternative,
+                            alpha=alpha,
+                            dist=dist,
+                            equal_var=equal_var,
+                            approx_t_method=approx_t_method,
+                        )
+                        - power
+                    )
+            case "t":
+                if reference_std is not None:
+
+                    def func(treatment_std: float) -> float:
+                        return (
+                            _power(
+                                diff=diff,
+                                margin=margin,
+                                treatment_std=treatment_std,
+                                reference_std=reference_std,
+                                treatment_size=treatment_size,
+                                reference_size=reference_size,
+                                alternative=alternative,
+                                alpha=alpha,
+                                dist=dist,
+                                equal_var=equal_var,
+                                approx_t_method=approx_t_method,
+                            )
+                            - power
+                        )
+                else:
+
+                    def func(treatment_std: float) -> float:
+                        return (
+                            _power(
+                                diff=diff,
+                                margin=margin,
+                                treatment_std=treatment_std,
+                                reference_std=treatment_std,
+                                treatment_size=treatment_size,
+                                reference_size=reference_size,
+                                alternative=alternative,
+                                alpha=alpha,
+                                dist=dist,
+                                equal_var=equal_var,
+                                approx_t_method=approx_t_method,
+                            )
+                            - power
+                        )
     else:  # equal_var == False
 
         def func(treatment_std: float) -> float:
             return (
                 _power(
                     diff=diff,
-                    treatment_mean=treatment_mean,
-                    reference_mean=reference_mean,
                     margin=margin,
                     treatment_std=treatment_std,
                     reference_std=reference_std,
@@ -782,134 +905,174 @@ def solve_treatment_std(
                     reference_size=reference_size,
                     alternative=alternative,
                     alpha=alpha,
-                    method=method,
+                    dist=dist,
                     equal_var=equal_var,
-                    df_adjust=df_adjust,
+                    approx_t_method=approx_t_method,
                 )
                 - power
             )
 
-    STD_SEARCH_MAX = 1000000
-
-    return float(brentq(func, 0.000001, STD_SEARCH_MAX))
+    return float(brentq(func, 1e-6, 1e6))
 
 
 def solve_reference_std(
     *,
-    diff: float | None = None,
     treatment_mean: float | None = None,
     reference_mean: float | None = None,
+    diff: float | None = None,
     margin: float,
+    treatment_std: float | None = None,
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.80,
-    method: Literal["z", "t"] = "t",
+    dist: Literal["z", "t"] = "t",
     equal_var: bool = True,
-    treatment_std: float | None = None,
-    df_adjust: Literal["welch", "satterthwaite"] = "welch",
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch",
 ) -> float:
     """
     Estimate the required standard deviation in the reference group for a superiority test of two independent means.
 
     Args:
-        diff (float, optional):
-            Mean difference between treatment and reference group ($\\mu_1 - \\mu_2$).
+        treatment_mean:
+            Mean in the treatment group.
 
-            If provided, `treatment_mean` and `reference_mean` will be ignored.
-        treatment_mean (float, optional):
-            Mean in the treatment group ($\\mu_1$).
+            If `diff` is not specified, this parameter must be specified along with `reference_mean`.
+        reference_mean:
+            Mean in the reference group.
 
-            If `diff` is not provided, this must be specified along with `reference_mean`.
-        reference_mean (float, optional):
-            Mean in the reference group ($\\mu_2$).
+            If `diff` is not specified, this parameter must be specified along with `treatment_mean`.
+        diff:
+            Mean difference between treatment and reference group.
 
-            If `diff` is not provided, this must be specified along with `treatment_mean`.
-        margin (float):
-            The superiority margin ($\\delta$)
+            If both `treatment_mean` and `reference_mean` are not specified, this parameter must be specified.
+        margin:
+            The superiority margin.
 
-            - provide a positive value if a higher mean is better
-            - provide a negative value if a higher mean is worse
-        treatment_size (int):
-            Sample size for the treatment group ($n_1$).
-        reference_size (int):
-            Sample size for the reference group ($n_2$).
-        alternative (Literal["greater", "less"]):
+            Regardless of whether `alternative` is specified as `greater` or `less`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `altarnative` is `greater`, the actual margin used internally is `abs(margin)`.
+            - If `altarnative` is `less`, the actual margin used internally is `-abs(margin)`.
+        treatment_std:
+            Standard deviation in the treatment group.
+
+            - If `dist` is `z` and `equal_var` is `True`, this parameter is ignored.
+            - If `dist` is `z` and `equal_var` is `False`, this parameter is required.
+            - If `dist` is `t` and `equal_var` is `True`, this parameter is optional. If specified, this value is used to calculate the standard error of mean difference.
+            - If `dist` is `t` and `equal_var` is `False`, this parameter is required.
+        alternative:
             Type of the alternative hypothesis.
 
-            - `'greater'`: upper-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 > \\delta$
-            - `'less'`: lower-tailed alternative hypothesis: $H_1: \\mu_1 - \\mu_2 < \\delta$
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Desired statistical power.
-        method (Literal["z", "t"], optional):
+            - If `altarnative` is `greater`, the alternative hypothesis is $\\mu_1 - \\mu_2 > \\delta$ ($\\delta \\geqslant 0$)
+            - If `altarnative` is `less`, the alternative hypothesis is $\\mu_1 - \\mu_2 < \\delta$ ($\\delta \\leqslant 0$)
+        alpha:
+            Significance level.
+
+            The superiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        dist:
             The distribution used for the test.
 
-            - `'z'`: Standard normal distribution (large sample approximation).
+            - `'z'`: Standard normal distribution.
             - `'t'`: Student's or non-central t distribution.
+        equal_var:
+            Whether to assume equal variances between treatment and reference groups.
 
-        equal_var (bool, optional):
-            Whether to assume equal variances between groups.
+            - `True`: Variances are assumed equal.
+            - `False`: Variances are assumed unequal.
 
-            - If True: Assume $\\sigma_1^2 = \\sigma_2^2$. Use *Pooled Variance* to calculate SE.
-              If `method='t'`, degree of freedom $df = n_1 + n_2 - 2$.
+        approx_t_method:
+            Approximate t-test method. It is used when `dist` is `'t'` and `equal_var` = `False`.
 
-            - If False: Assume $\\sigma_1^2 \\neq \\sigma_2^2$. Use *Unpooled Variance* to calculate SE.
-              If `method='t'`, the degree of freedom is adjusted based on the `df_adjust` parameter.
-
-            If Z test is used and `equal_var` is True, the standard deviation of the two groups must be equal.
-        treatment_std (float | None, optional):
-            Standard deviation in the treatment group ($\\sigma_2$).
-
-            If `equal_var=True`, this parameter is ignored, otherwise, you must specify this parameter.
-        df_adjust (Literal["welch", "satterthwaite"], optional):
-            Degree of freedom adjustment method when `method="t"` and `equal_var=False`.
-
-            - `'welch'`: Adjustment based on Welch (1947).
-            - `'satterthwaite'`: Adjustment based on Satterthwaite (1946).
+            - `'welch'`: Welch's approximate t-test (1947).
+            - `'satterthwaite'`: Satterthwaite's approximate t-test (1946).
 
     Returns:
-        (float): The required standard deviation in the reference group.
+        float: The required standard deviation in the reference group.
 
     Raises:
-        ValueError: If `diff` is not provided, and either `treatment_mean` or `reference_mean` is not provided.
-        ValueError: If `equal_var=False` and `treatment_std=None`.
+        ValueError: If `diff` is not specified, and neither `treatment_mean` nor `reference_mean` is not specified.
+        ValueError: If `equal_var` is `False`, and `treatment_std` is not specified.
     """
 
+    diff = _verify_mean_and_get_diff(treatment_mean, reference_mean, diff)
+
     if not equal_var and treatment_std is None:
-        raise ValueError("treatment_std must be provided when equal_var=False.")
+        raise ValueError("'treatment_std' must be specified when 'equal_var' = False.")
+
+    margin = _margin(margin, alternative)
 
     if equal_var:
+        match dist:
+            case "z":
 
-        def func(reference_std: float) -> float:
-            return (
-                _power(
-                    diff=diff,
-                    treatment_mean=treatment_mean,
-                    reference_mean=reference_mean,
-                    margin=margin,
-                    treatment_std=reference_std,
-                    reference_std=reference_std,
-                    treatment_size=treatment_size,
-                    reference_size=reference_size,
-                    alternative=alternative,
-                    alpha=alpha,
-                    method=method,
-                    equal_var=equal_var,
-                    df_adjust=df_adjust,
-                )
-                - power
-            )
+                def func(reference_std: float) -> float:
+                    return (
+                        _power(
+                            diff=diff,
+                            margin=margin,
+                            std=reference_std,
+                            treatment_size=treatment_size,
+                            reference_size=reference_size,
+                            alternative=alternative,
+                            alpha=alpha,
+                            dist=dist,
+                            equal_var=equal_var,
+                            approx_t_method=approx_t_method,
+                        )
+                        - power
+                    )
+            case "t":
+                if treatment_std is not None:
+
+                    def func(reference_std: float) -> float:
+                        return (
+                            _power(
+                                diff=diff,
+                                margin=margin,
+                                treatment_std=treatment_std,
+                                reference_std=reference_std,
+                                treatment_size=treatment_size,
+                                reference_size=reference_size,
+                                alternative=alternative,
+                                alpha=alpha,
+                                dist=dist,
+                                equal_var=equal_var,
+                                approx_t_method=approx_t_method,
+                            )
+                            - power
+                        )
+                else:
+
+                    def func(reference_std: float) -> float:
+                        return (
+                            _power(
+                                diff=diff,
+                                margin=margin,
+                                treatment_std=reference_std,
+                                reference_std=reference_std,
+                                treatment_size=treatment_size,
+                                reference_size=reference_size,
+                                alternative=alternative,
+                                alpha=alpha,
+                                dist=dist,
+                                equal_var=equal_var,
+                                approx_t_method=approx_t_method,
+                            )
+                            - power
+                        )
+
     else:  # equal_var == False
 
         def func(reference_std: float) -> float:
             return (
                 _power(
                     diff=diff,
-                    treatment_mean=treatment_mean,
-                    reference_mean=reference_mean,
                     margin=margin,
                     treatment_std=treatment_std,
                     reference_std=reference_std,
@@ -917,13 +1080,11 @@ def solve_reference_std(
                     reference_size=reference_size,
                     alternative=alternative,
                     alpha=alpha,
-                    method=method,
+                    dist=dist,
                     equal_var=equal_var,
-                    df_adjust=df_adjust,
+                    approx_t_method=approx_t_method,
                 )
                 - power
             )
 
-    STD_SEARCH_MAX = 1000000
-
-    return float(brentq(func, 0.000001, STD_SEARCH_MAX))
+    return float(brentq(func, 1e-6, 1e6))

--- a/tests/test_mean/test_independent/test_superiority.py
+++ b/tests/test_mean/test_independent/test_superiority.py
@@ -6,505 +6,671 @@ from typing import Literal
 
 import pytest
 
-from pystatpower.mean.independent.superiority import solve_power, solve_size, solve_diff, solve_margin, solve_treatment_std, solve_reference_std
+from pystatpower.mean.independent._verify import _verify_mean_and_get_diff, _verify_std_and_get_std
+from pystatpower.mean.independent.superiority import solve_power, solve_size, solve_treatment_mean, solve_reference_mean, solve_diff, solve_margin, solve_treatment_std, solve_reference_std
 
 from tests.models import BaseTestCase
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TestCase(BaseTestCase):
-    treatment_mean: float
-    reference_mean: float
+    treatment_mean: float | None = None
+    reference_mean: float | None = None
+    diff: float | None = None
     margin: float
-    treatment_std: float
-    reference_std: float
+    treatment_std: float | None = None
+    reference_std: float | None = None
+    std: float | None = None
     treatment_size: int
     reference_size: int
     alternative: Literal["greater", "less"]
     alpha: float
     power: float
     actual_power: float
-    method: Literal["z", "t"]
+    dist: Literal["z", "t"]
     equal_var: bool
-    df_adjust: Literal["welch", "satterthwaite"] | None = None
+    approx_t_method: Literal["welch", "satterthwaite"] = "welch"
+
+    def __post_init__(self) -> None:
+        self.diff = _verify_mean_and_get_diff(self.treatment_mean, self.reference_mean, self.diff)
+        self.std = _verify_std_and_get_std(self.treatment_std, self.reference_std, self.std, self.dist, self.equal_var)
 
 
-case_group = (
-    [
-        # Regular Cases: diff = -30, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "t", equal_var = True
-        TestCase(
-            treatment_mean=10,
-            reference_mean=40,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="less",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="t",
-            equal_var=True,
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (-20, 379, 190, 0.8017),
-            (-19, 313, 157, 0.8013),
-            (-18, 263, 132, 0.8011),
-            (-17, 225, 113, 0.8025),
-            (-16, 193, 97, 0.8003),
-            (-15, 169, 85, 0.8022),
-            (-14, 149, 75, 0.8032),
-            (-13, 131, 66, 0.8000),
-            (-12, 117, 59, 0.8003),
-            (-11, 105, 53, 0.8000),
-            (-10, 95, 48, 0.8007),
-        ]
+# The superiority module of PASS 15 does not support z-test. The test cases here are verified by AI.
+case_group_z_equal_var = [
+    # treatment_mean = 10, reference_mean = 40, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "z", equal_var = True
+    TestCase(
+        treatment_mean=10,
+        reference_mean=40,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="less",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="z",
+        equal_var=True,
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (-20, 378, 189, 0.8013),
+        (-19, 312, 156, 0.8008),
+        (-18, 262, 131, 0.8006),
+        (-17, 224, 112, 0.8019),
+        (-16, 194, 97, 0.8036),
+        (-15, 168, 84, 0.8013),
+        (-14, 148, 74, 0.8022),
+        (-13, 132, 66, 0.8049),
+        (-12, 118, 59, 0.8057),
+        (-11, 106, 53, 0.8061),
+        (-10, 96, 48, 0.8074),
     ]
-    + [
-        # Regular Cases: diff = 30, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 0.5, alpha = 0.025, power = 0.80, method = "t", equal_var = True
-        TestCase(
-            treatment_mean=40,
-            reference_mean=10,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="greater",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="t",
-            equal_var=True,
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (10, 48, 96, 0.8021),
-            (11, 53, 106, 0.8013),
-            (12, 59, 118, 0.8014),
-            (13, 66, 132, 0.8010),
-            (14, 75, 150, 0.8041),
-            (15, 85, 170, 0.8029),
-            (16, 97, 194, 0.8010),
-            (17, 113, 226, 0.8031),
-            (18, 132, 264, 0.8016),
-            (19, 157, 314, 0.8017),
-            (20, 190, 380, 0.8020),
-        ]
+] + [
+    # treatment_mean = 40, reference_mean = 10, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "z", equal_var = True
+    TestCase(
+        treatment_mean=40,
+        reference_mean=10,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="greater",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="z",
+        equal_var=True,
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (10, 48, 96, 0.8074),
+        (11, 53, 106, 0.8061),
+        (12, 59, 118, 0.8057),
+        (13, 66, 132, 0.8049),
+        (14, 74, 148, 0.8022),
+        (15, 84, 168, 0.8013),
+        (16, 97, 194, 0.8036),
+        (17, 112, 224, 0.8019),
+        (18, 131, 262, 0.8006),
+        (19, 156, 312, 0.8008),
+        (20, 189, 378, 0.8013),
     ]
-    + [
-        # Regular Cases: diff = -30, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "t", equal_var = False, df_adjust = "welch"
-        TestCase(
-            treatment_mean=10,
-            reference_mean=40,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="less",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="t",
-            equal_var=False,
-            df_adjust="welch",
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (-20, 379, 190, 0.8010),
-            (-19, 313, 157, 0.8005),
-            (-18, 263, 132, 0.8002),
-            (-17, 225, 113, 0.8014),
-            (-16, 195, 98, 0.8031),
-            (-15, 169, 85, 0.8007),
-            (-14, 149, 75, 0.8016),
-            (-13, 133, 67, 0.8041),
-            (-12, 119, 60, 0.8049),
-            (-11, 107, 54, 0.8052),
-            (-10, 97, 49, 0.8064),
-        ]
+]
+
+# The superiority module of PASS 15 does not support z-test. The test cases here are verified by AI.
+case_group_z_unequal_var = [
+    # treatment_mean = 10, reference_mean = 40, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 30, ratio = 2, alpha = 0.025, power = 0.80, dist = "z", equal_var = False
+    TestCase(
+        treatment_mean=10,
+        reference_mean=40,
+        margin=margin,
+        treatment_std=40,
+        reference_std=30,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="less",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="z",
+        equal_var=False,
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (-20, 268, 134, 0.8017),
+        (-19, 222, 111, 0.8026),
+        (-18, 186, 93, 0.8014),
+        (-17, 158, 80, 0.8028),
+        (-16, 138, 69, 0.8053),
+        (-15, 120, 60, 0.8046),
+        (-14, 106, 53, 0.8065),
+        (-13, 94, 47, 0.8069),
+        (-12, 84, 42, 0.8077),
+        (-11, 74, 37, 0.8004),
+        (-10, 68, 34, 0.8074),
     ]
-    + [
-        # Regular Cases: diff = 30, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "t", equal_var = False, df_adjust = "welch"
-        TestCase(
-            treatment_mean=40,
-            reference_mean=10,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="greater",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="t",
-            equal_var=False,
-            df_adjust="welch",
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (10, 49, 98, 0.8077),
-            (11, 54, 108, 0.8064),
-            (12, 60, 120, 0.8060),
-            (13, 67, 134, 0.8051),
-            (14, 75, 150, 0.8024),
-            (15, 85, 170, 0.8015),
-            (16, 98, 196, 0.8038),
-            (17, 113, 226, 0.8020),
-            (18, 132, 264, 0.8007),
-            (19, 157, 314, 0.8009),
-            (20, 190, 380, 0.8014),
-        ]
+] + [
+    # treatment_mean = 40, reference_mean = 10, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 30, ratio = 2, alpha = 0.025, power = 0.80, dist = "z", equal_var = False
+    TestCase(
+        treatment_mean=40,
+        reference_mean=10,
+        margin=margin,
+        treatment_std=40,
+        reference_std=30,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="greater",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="z",
+        equal_var=False,
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (10, 41, 82, 0.8074),
+        (11, 45, 90, 0.8037),
+        (12, 50, 100, 0.8027),
+        (13, 56, 112, 0.8023),
+        (14, 63, 126, 0.8009),
+        (15, 72, 144, 0.8027),
+        (16, 83, 166, 0.8043),
+        (17, 96, 192, 0.8032),
+        (18, 112, 224, 0.8009),
+        (19, 133, 266, 0.8001),
+        (20, 161, 322, 0.8002),
     ]
-    + [
-        # Regular Cases: diff = -30, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "t", equal_var = False, df_adjust = "satterthwaite"
-        TestCase(
-            treatment_mean=10,
-            reference_mean=40,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="less",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="t",
-            equal_var=False,
-            df_adjust="satterthwaite",
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (-20, 379, 190, 0.8010),
-            (-19, 313, 157, 0.8005),
-            (-18, 263, 132, 0.8002),
-            (-17, 225, 113, 0.8014),
-            (-16, 195, 98, 0.8031),
-            (-15, 169, 85, 0.8007),
-            (-14, 149, 75, 0.8015),
-            (-13, 133, 67, 0.8041),
-            (-12, 119, 60, 0.8048),
-            (-11, 107, 54, 0.8051),
-            (-10, 97, 49, 0.8063),
-        ]
+]
+
+case_group_t_equal_var = [
+    # treatment_mean = 10, reference_mean = 40, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "t", equal_var = True
+    TestCase(
+        treatment_mean=10,
+        reference_mean=40,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="less",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="t",
+        equal_var=True,
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (-20, 379, 190, 0.8017),
+        (-19, 313, 157, 0.8013),
+        (-18, 263, 132, 0.8011),
+        (-17, 225, 113, 0.8025),
+        (-16, 193, 97, 0.8003),
+        (-15, 169, 85, 0.8022),
+        (-14, 149, 75, 0.8032),
+        (-13, 131, 66, 0.8000),
+        (-12, 117, 59, 0.8003),
+        (-11, 105, 53, 0.8000),
+        (-10, 95, 48, 0.8007),
     ]
-    + [
-        # Regular Cases: diff = 30, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "t", equal_var = False, df_adjust = "satterthwaite"
-        TestCase(
-            treatment_mean=40,
-            reference_mean=10,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="greater",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="t",
-            equal_var=False,
-            df_adjust="satterthwaite",
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (10, 49, 98, 0.8076),
-            (11, 54, 108, 0.8062),
-            (12, 60, 120, 0.8059),
-            (13, 67, 134, 0.8050),
-            (14, 75, 150, 0.8024),
-            (15, 85, 170, 0.8014),
-            (16, 98, 196, 0.8037),
-            (17, 113, 226, 0.8020),
-            (18, 132, 264, 0.8007),
-            (19, 157, 314, 0.8009),
-            (20, 190, 380, 0.8014),
-        ]
+] + [
+    # treatment_mean = 40, reference_mean = 10, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 0.5, alpha = 0.025, power = 0.80, dist = "t", equal_var = True
+    TestCase(
+        treatment_mean=40,
+        reference_mean=10,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="greater",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="t",
+        equal_var=True,
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (10, 48, 96, 0.8021),
+        (11, 53, 106, 0.8013),
+        (12, 59, 118, 0.8014),
+        (13, 66, 132, 0.8010),
+        (14, 75, 150, 0.8041),
+        (15, 85, 170, 0.8029),
+        (16, 97, 194, 0.8010),
+        (17, 113, 226, 0.8031),
+        (18, 132, 264, 0.8016),
+        (19, 157, 314, 0.8017),
+        (20, 190, 380, 0.8020),
     ]
-    + [
-        # Regular Cases: diff = -30, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "z", equal_var = True
-        TestCase(
-            treatment_mean=10,
-            reference_mean=40,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="less",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="z",
-            equal_var=True,
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (-20, 378, 189, 0.8013),
-            (-19, 312, 156, 0.8008),
-            (-18, 262, 131, 0.8006),
-            (-17, 224, 112, 0.8019),
-            (-16, 194, 97, 0.8036),
-            (-15, 168, 84, 0.8013),
-            (-14, 148, 74, 0.8022),
-            (-13, 132, 66, 0.8049),
-            (-12, 118, 59, 0.8057),
-            (-11, 106, 53, 0.8061),
-            (-10, 96, 48, 0.8074),
-        ]
+]
+
+case_group_t_unequal_var_welch = [
+    # treatment_mean = 10, reference_mean = 40, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "t", equal_var = False, approx_t_method = "welch"
+    TestCase(
+        treatment_mean=10,
+        reference_mean=40,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="less",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="t",
+        equal_var=False,
+        approx_t_method="welch",
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (-20, 379, 190, 0.8010),
+        (-19, 313, 157, 0.8005),
+        (-18, 263, 132, 0.8002),
+        (-17, 225, 113, 0.8014),
+        (-16, 195, 98, 0.8031),
+        (-15, 169, 85, 0.8007),
+        (-14, 149, 75, 0.8016),
+        (-13, 133, 67, 0.8041),
+        (-12, 119, 60, 0.8049),
+        (-11, 107, 54, 0.8052),
+        (-10, 97, 49, 0.8064),
     ]
-    + [
-        # Regular Cases: diff = 30, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, method = "z", equal_var = True
-        TestCase(
-            treatment_mean=40,
-            reference_mean=10,
-            margin=margin,
-            treatment_std=40,
-            reference_std=40,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="greater",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="z",
-            equal_var=True,
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (10, 48, 96, 0.8074),
-            (11, 53, 106, 0.8061),
-            (12, 59, 118, 0.8057),
-            (13, 66, 132, 0.8049),
-            (14, 74, 148, 0.8022),
-            (15, 84, 168, 0.8013),
-            (16, 97, 194, 0.8036),
-            (17, 112, 224, 0.8019),
-            (18, 131, 262, 0.8006),
-            (19, 156, 312, 0.8008),
-            (20, 189, 378, 0.8013),
-        ]
+] + [
+    # treatment_mean = 40, reference_mean = 10, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "t", equal_var = False, approx_t_method = "welch"
+    TestCase(
+        treatment_mean=40,
+        reference_mean=10,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="greater",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="t",
+        equal_var=False,
+        approx_t_method="welch",
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (10, 49, 98, 0.8077),
+        (11, 54, 108, 0.8064),
+        (12, 60, 120, 0.8060),
+        (13, 67, 134, 0.8051),
+        (14, 75, 150, 0.8024),
+        (15, 85, 170, 0.8015),
+        (16, 98, 196, 0.8038),
+        (17, 113, 226, 0.8020),
+        (18, 132, 264, 0.8007),
+        (19, 157, 314, 0.8009),
+        (20, 190, 380, 0.8014),
     ]
-    + [
-        # Regular Cases: diff = -30, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 30, ratio = 2, alpha = 0.025, power = 0.80, method = "z", equal_var = False
-        TestCase(
-            treatment_mean=10,
-            reference_mean=40,
-            margin=margin,
-            treatment_std=40,
-            reference_std=30,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="less",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="z",
-            equal_var=False,
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (-20, 268, 134, 0.8017),
-            (-19, 222, 111, 0.8026),
-            (-18, 186, 93, 0.8014),
-            (-17, 158, 80, 0.8028),
-            (-16, 138, 69, 0.8053),
-            (-15, 120, 60, 0.8046),
-            (-14, 106, 53, 0.8065),
-            (-13, 94, 47, 0.8069),
-            (-12, 84, 42, 0.8077),
-            (-11, 74, 37, 0.8004),
-            (-10, 68, 34, 0.8074),
-        ]
+]
+
+case_group_t_unequal_var_satterthwaite = [
+    # treatment_mean = 10, reference_mean = 40, margin = -20 to -10 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "t", equal_var = False, approx_t_method = "satterthwaite"
+    TestCase(
+        treatment_mean=10,
+        reference_mean=40,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="less",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="t",
+        equal_var=False,
+        approx_t_method="satterthwaite",
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (-20, 379, 190, 0.8010),
+        (-19, 313, 157, 0.8005),
+        (-18, 263, 132, 0.8002),
+        (-17, 225, 113, 0.8014),
+        (-16, 195, 98, 0.8031),
+        (-15, 169, 85, 0.8007),
+        (-14, 149, 75, 0.8015),
+        (-13, 133, 67, 0.8041),
+        (-12, 119, 60, 0.8048),
+        (-11, 107, 54, 0.8051),
+        (-10, 97, 49, 0.8063),
     ]
-    + [
-        # Regular Cases: diff = 30, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 30, ratio = 2, alpha = 0.025, power = 0.80, method = "z", equal_var = False
-        TestCase(
-            treatment_mean=40,
-            reference_mean=10,
-            margin=margin,
-            treatment_std=40,
-            reference_std=30,
-            treatment_size=treatment_size,
-            reference_size=reference_size,
-            alternative="greater",
-            alpha=0.025,
-            power=0.80,
-            actual_power=actual_power,
-            method="z",
-            equal_var=False,
-        )
-        for margin, treatment_size, reference_size, actual_power in [
-            (10, 41, 82, 0.8074),
-            (11, 45, 90, 0.8037),
-            (12, 50, 100, 0.8027),
-            (13, 56, 112, 0.8023),
-            (14, 63, 126, 0.8009),
-            (15, 72, 144, 0.8027),
-            (16, 83, 166, 0.8043),
-            (17, 96, 192, 0.8032),
-            (18, 112, 224, 0.8009),
-            (19, 133, 266, 0.8001),
-            (20, 161, 322, 0.8002),
-        ]
+] + [
+    # treatment_mean = 40, reference_mean = 10, margin = 10 to 20 by 1, treatment_std = 40, reference_std = 40, ratio = 2, alpha = 0.025, power = 0.80, dist = "t", equal_var = False, approx_t_method = "satterthwaite"
+    TestCase(
+        treatment_mean=40,
+        reference_mean=10,
+        margin=margin,
+        treatment_std=40,
+        reference_std=40,
+        treatment_size=treatment_size,
+        reference_size=reference_size,
+        alternative="greater",
+        alpha=0.025,
+        power=0.80,
+        actual_power=actual_power,
+        dist="t",
+        equal_var=False,
+        approx_t_method="satterthwaite",
+    )
+    for margin, treatment_size, reference_size, actual_power in [
+        (10, 49, 98, 0.8076),
+        (11, 54, 108, 0.8062),
+        (12, 60, 120, 0.8059),
+        (13, 67, 134, 0.8050),
+        (14, 75, 150, 0.8024),
+        (15, 85, 170, 0.8014),
+        (16, 98, 196, 0.8037),
+        (17, 113, 226, 0.8020),
+        (18, 132, 264, 0.8007),
+        (19, 157, 314, 0.8009),
+        (20, 190, 380, 0.8014),
     ]
-)
+]
+
+case_group = case_group_z_equal_var + case_group_z_unequal_var + case_group_t_equal_var + case_group_t_unequal_var_welch + case_group_t_unequal_var_satterthwaite
 
 
 def test_solve_power(case: TestCase) -> None:
-    assert (
-        round(
-            solve_power(
-                treatment_mean=case.treatment_mean,
-                reference_mean=case.reference_mean,
-                margin=case.margin,
-                treatment_std=case.treatment_std,
-                reference_std=case.reference_std,
-                treatment_size=case.treatment_size,
-                reference_size=case.reference_size,
-                alternative=case.alternative,
-                alpha=case.alpha,
-                method=case.method,
-                equal_var=case.equal_var,
-                df_adjust=case.df_adjust,
-            ),
-            4,
-        )
-        == case.actual_power
-    )
-
-
-def test_solve_power_error() -> None:
-    with pytest.raises(ValueError):
-        solve_power(diff=0, margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z", equal_var=True)
-    with pytest.raises(ValueError):
-        solve_power(treatment_mean=10, margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z")
+    assert round(
+        solve_power(
+            treatment_mean=case.treatment_mean,
+            reference_mean=case.reference_mean,
+            diff=case.diff,
+            margin=case.margin,
+            treatment_std=case.treatment_std,
+            reference_std=case.reference_std,
+            std=case.std,
+            treatment_size=case.treatment_size,
+            reference_size=case.reference_size,
+            alternative=case.alternative,
+            alpha=case.alpha,
+            dist=case.dist,
+            equal_var=case.equal_var,
+            approx_t_method=case.approx_t_method,
+        ),
+        4,
+    ) == round(case.actual_power, 4)
 
 
 def test_solve_size(case: TestCase) -> None:
-    if case == TestCase(
-        treatment_mean=40,
-        reference_mean=10,
-        margin=13,
-        treatment_std=40,
-        reference_std=40,
-        treatment_size=67,
-        reference_size=134,
-        alternative="greater",
-        alpha=0.025,
-        power=0.8,
-        actual_power=0.8051,
-        method="t",
-        equal_var=False,
-        df_adjust="welch",
-    ):
+    if case in [
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=13,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=67,
+            reference_size=134,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8051,
+            dist="t",
+            equal_var=False,
+            approx_t_method="welch",
+        ),
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=10,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=49,
+            reference_size=98,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8076,
+            dist="t",
+            equal_var=False,
+            approx_t_method="satterthwaite",
+        ),
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=15,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=85,
+            reference_size=170,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8014,
+            dist="t",
+            equal_var=False,
+            approx_t_method="satterthwaite",
+        ),
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=19,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=157,
+            reference_size=314,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8009,
+            dist="t",
+            equal_var=False,
+            approx_t_method="satterthwaite",
+        ),
+    ]:
         pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
 
     ratio = case.treatment_size / case.reference_size
     assert solve_size(
         treatment_mean=case.treatment_mean,
         reference_mean=case.reference_mean,
+        diff=case.diff,
         margin=case.margin,
         treatment_std=case.treatment_std,
         reference_std=case.reference_std,
+        std=case.std,
         ratio=ratio,
         alternative=case.alternative,
         alpha=case.alpha,
         power=case.power,
-        method=case.method,
+        dist=case.dist,
         equal_var=case.equal_var,
-        df_adjust=case.df_adjust,
+        approx_t_method=case.approx_t_method,
     ) == (case.treatment_size, case.reference_size)
 
 
-def test_solve_size_error() -> None:
-    with pytest.raises(ValueError):
-        solve_size(diff=0, margin=10, treatment_std=10, reference_std=20, ratio=1, alternative="greater", method="z", equal_var=True)
+def test_solve_treatment_mean(case: TestCase) -> None:
+    if case in [
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=15,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=85,
+            reference_size=170,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8015,
+            dist="t",
+            equal_var=False,
+            approx_t_method="welch",
+        ),
+    ]:
+        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+
+    assert (
+        round(
+            solve_treatment_mean(
+                reference_mean=case.reference_mean,
+                margin=case.margin,
+                treatment_std=case.treatment_std,
+                reference_std=case.reference_std,
+                std=case.std,
+                treatment_size=case.treatment_size,
+                reference_size=case.reference_size,
+                alternative=case.alternative,
+                alpha=case.alpha,
+                power=case.actual_power,
+                dist=case.dist,
+                equal_var=case.equal_var,
+                approx_t_method=case.approx_t_method,
+            ),
+            0,
+        )
+        == case.treatment_mean
+    )
+
+
+def test_solve_reference_mean(case: TestCase) -> None:
+    if case in [
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=15,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=85,
+            reference_size=170,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8015,
+            dist="t",
+            equal_var=False,
+            approx_t_method="welch",
+        ),
+    ]:
+        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+
+    assert (
+        round(
+            solve_reference_mean(
+                treatment_mean=case.treatment_mean,
+                margin=case.margin,
+                treatment_std=case.treatment_std,
+                reference_std=case.reference_std,
+                std=case.std,
+                treatment_size=case.treatment_size,
+                reference_size=case.reference_size,
+                alternative=case.alternative,
+                alpha=case.alpha,
+                power=case.actual_power,
+                dist=case.dist,
+                equal_var=case.equal_var,
+                approx_t_method=case.approx_t_method,
+            ),
+            0,
+        )
+        == case.reference_mean
+    )
 
 
 def test_solve_diff(case: TestCase) -> None:
-    if case == TestCase(
-        treatment_mean=40,
-        reference_mean=10,
-        margin=16,
-        treatment_std=40,
-        reference_std=40,
-        treatment_size=98,
-        reference_size=196,
-        alternative="greater",
-        alpha=0.025,
-        power=0.8,
-        actual_power=0.8037,
-        method="t",
-        equal_var=False,
-        df_adjust="satterthwaite",
-    ) or case == TestCase(
-        treatment_mean=40,
-        reference_mean=10,
-        margin=16,
-        treatment_std=40,
-        reference_std=40,
-        treatment_size=98,
-        reference_size=196,
-        alternative="greater",
-        alpha=0.025,
-        power=0.8,
-        actual_power=0.8038,
-        method="t",
-        equal_var=False,
-        df_adjust="welch",
-    ):
+    if case in [
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=15,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=85,
+            reference_size=170,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8015,
+            dist="t",
+            equal_var=False,
+            approx_t_method="welch",
+        ),
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=16,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=98,
+            reference_size=196,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8038,
+            dist="t",
+            equal_var=False,
+            approx_t_method="welch",
+        ),
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=16,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=98,
+            reference_size=196,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8037,
+            dist="t",
+            equal_var=False,
+            approx_t_method="satterthwaite",
+        ),
+    ]:
         pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
 
-    diff = case.treatment_mean - case.reference_mean
     assert (
         round(
             solve_diff(
                 margin=case.margin,
                 treatment_std=case.treatment_std,
                 reference_std=case.reference_std,
+                std=case.std,
                 treatment_size=case.treatment_size,
                 reference_size=case.reference_size,
                 alternative=case.alternative,
                 alpha=case.alpha,
                 power=case.actual_power,
-                method=case.method,
+                dist=case.dist,
                 equal_var=case.equal_var,
-                df_adjust=case.df_adjust,
+                approx_t_method=case.approx_t_method,
             ),
             0,
         )
-        == diff
+        == case.diff
     )
 
 
-def test_solve_diff_error() -> None:
-    with pytest.raises(ValueError):
-        solve_diff(margin=10, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z", equal_var=True)
-
-
 def test_solve_margin(case: TestCase) -> None:
-    diff = case.treatment_mean - case.reference_mean
+    if case in [
+        TestCase(
+            treatment_mean=40,
+            reference_mean=10,
+            margin=15,
+            treatment_std=40,
+            reference_std=40,
+            treatment_size=85,
+            reference_size=170,
+            alternative="greater",
+            alpha=0.025,
+            power=0.8,
+            actual_power=0.8015,
+            dist="t",
+            equal_var=False,
+            approx_t_method="welch",
+        ),
+    ]:
+        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+
     assert (
         round(
             solve_margin(
-                diff=diff,
+                treatment_mean=case.treatment_mean,
+                reference_mean=case.reference_mean,
+                diff=case.diff,
                 treatment_std=case.treatment_std,
                 reference_std=case.reference_std,
+                std=case.std,
                 treatment_size=case.treatment_size,
                 reference_size=case.reference_size,
                 alternative=case.alternative,
                 alpha=case.alpha,
                 power=case.actual_power,
-                method=case.method,
+                dist=case.dist,
                 equal_var=case.equal_var,
-                df_adjust=case.df_adjust,
+                approx_t_method=case.approx_t_method,
             ),
             0,
         )
         == case.margin
     )
-
-
-def test_solve_margin_error() -> None:
-    with pytest.raises(ValueError):
-        solve_margin(diff=0, treatment_std=10, reference_std=20, treatment_size=20, reference_size=20, alternative="greater", method="z", equal_var=True)
 
 
 def test_solve_treatment_std(case: TestCase) -> None:
@@ -513,28 +679,49 @@ def test_solve_treatment_std(case: TestCase) -> None:
             solve_treatment_std(
                 treatment_mean=case.treatment_mean,
                 reference_mean=case.reference_mean,
+                diff=case.diff,
                 margin=case.margin,
+                reference_std=case.reference_std,
                 treatment_size=case.treatment_size,
                 reference_size=case.reference_size,
                 alternative=case.alternative,
                 alpha=case.alpha,
                 power=case.actual_power,
-                method=case.method,
+                dist=case.dist,
                 equal_var=case.equal_var,
-                reference_std=case.reference_std,
-                df_adjust=case.df_adjust,
+                approx_t_method=case.approx_t_method,
             ),
             0,
         )
         == case.treatment_std
     )
 
+    if case.dist == "t" and case.equal_var:
+        assert (
+            round(
+                solve_treatment_std(
+                    treatment_mean=case.treatment_mean,
+                    reference_mean=case.reference_mean,
+                    diff=case.diff,
+                    margin=case.margin,
+                    treatment_size=case.treatment_size,
+                    reference_size=case.reference_size,
+                    alternative=case.alternative,
+                    alpha=case.alpha,
+                    power=case.actual_power,
+                    dist=case.dist,
+                    equal_var=case.equal_var,
+                    approx_t_method=case.approx_t_method,
+                ),
+                0,
+            )
+            == case.treatment_std
+        )
+
 
 def test_solve_treatment_std_error() -> None:
     with pytest.raises(ValueError):
         solve_treatment_std(diff=0, margin=10, treatment_size=20, reference_size=20, alternative="greater", equal_var=False)
-    with pytest.raises(ValueError):
-        solve_treatment_std(treatment_mean=10, margin=10, treatment_size=20, alternative="greater", reference_size=20)
 
 
 def test_solve_reference_std(case: TestCase) -> None:
@@ -543,25 +730,46 @@ def test_solve_reference_std(case: TestCase) -> None:
             solve_reference_std(
                 treatment_mean=case.treatment_mean,
                 reference_mean=case.reference_mean,
+                diff=case.diff,
                 margin=case.margin,
+                treatment_std=case.treatment_std,
                 treatment_size=case.treatment_size,
                 reference_size=case.reference_size,
                 alternative=case.alternative,
                 alpha=case.alpha,
                 power=case.actual_power,
-                method=case.method,
+                dist=case.dist,
                 equal_var=case.equal_var,
-                treatment_std=case.treatment_std,
-                df_adjust=case.df_adjust,
+                approx_t_method=case.approx_t_method,
             ),
             0,
         )
         == case.reference_std
     )
 
+    if case.dist == "t" and case.equal_var:
+        assert (
+            round(
+                solve_reference_std(
+                    treatment_mean=case.treatment_mean,
+                    reference_mean=case.reference_mean,
+                    diff=case.diff,
+                    margin=case.margin,
+                    treatment_size=case.treatment_size,
+                    reference_size=case.reference_size,
+                    alternative=case.alternative,
+                    alpha=case.alpha,
+                    power=case.actual_power,
+                    dist=case.dist,
+                    equal_var=case.equal_var,
+                    approx_t_method=case.approx_t_method,
+                ),
+                0,
+            )
+            == case.reference_std
+        )
+
 
 def test_solve_reference_std_error() -> None:
     with pytest.raises(ValueError):
         solve_reference_std(diff=0, margin=10, treatment_size=20, reference_size=20, alternative="greater", equal_var=False)
-    with pytest.raises(ValueError):
-        solve_reference_std(treatment_mean=10, margin=10, treatment_size=20, reference_size=20, alternative="greater", equal_var=False)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Extracted power calculation into separate `_power` module

- Added `_verify` helpers for mean diff and std validation

- Renamed parameters: `method` → `dist`, `df_adjust` → `approx_t_method`

- Introduced convenience `std` parameter for equal-variance z-test

- Added `solve_treatment_mean` and `solve_reference_mean` solvers

- Enhanced test suite with z-test cases and new solver tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["superiority.py"]
    B["_power.py (new)"]
    C["_verify.py (new)"]
    D["New solve_treatment_mean, solve_reference_mean"]
    A -- "imports" --> B
    A -- "imports" --> C
    A -- "adds" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>superiority.py</strong><dd><code>Refactor and enhance superiority test functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/mean/independent/superiority.py

<ul><li>Removed duplicated internal power functions (z/t, equal/unequal, <br>Welch/Satterthwaite)<br> <li> Imported consolidated <code>_power</code> from new <code>_power</code> module<br> <li> Imported <code>_verify_mean_and_get_diff</code> and <code>_verify_std_and_get_std</code> from <br>new <code>_verify</code> module<br> <li> Added <code>_margin</code> helper to normalise margin based on alternative<br> <li> Renamed <code>method</code> parameter to <code>dist</code>, <code>df_adjust</code> to <code>approx_t_method</code><br> <li> Added optional <code>std</code> parameter for equal‑variance z‑test convenience<br> <li> Added <code>solve_treatment_mean</code> and <code>solve_reference_mean</code> functions<br> <li> Fixed sample‑size search bounds, replaced magic constants with <br>1e‑12/1e12</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/434/files#diff-3aedf930efbf3ef56e29260dafeb6fe935c9d5ad5992b9fbfcabcece7c17c70a">+762/-601</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_superiority.py</strong><dd><code>Expand test coverage for refactored superiority module</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_mean/test_independent/test_superiority.py

<ul><li>Imported <code>solve_treatment_mean</code>, <code>solve_reference_mean</code> and new verify <br>helpers<br> <li> Made <code>TestCase</code> dataclass <code>kw_only</code> and added <code>__post_init__</code> to compute <br><code>diff</code> and <code>std</code><br> <li> Added extensive test groups for z‑test (equal/unequal var) validated <br>by AI<br> <li> Added test functions for <code>solve_treatment_mean</code> and <code>solve_reference_mean</code><br> <li> Updated existing tests to use renamed parameters (<code>dist</code>, <br><code>approx_t_method</code>, <code>std</code>)<br> <li> Marked certain tests as xfail due to SciPy upstream bug #25106</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/434/files#diff-c7f16c1716107659f3b80fd48cfa8173125ccf6ac0eb2c2d4c9455e3d2fca210">+601/-393</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

