### PR TITLE
docs(mean.independent.inequality): fix incorrect formulas and polish the docs

### DIFF
--- a/docs/algorithms/mean/independent/inequality.md
+++ b/docs/algorithms/mean/independent/inequality.md
@@ -27,47 +27,46 @@ H_1 &: \mu_1 \gt \mu_2
 \end{align}
 $$
 
-
-两样本均值分别用 $\hat{\mu}_1$ 和 $\hat{\mu}_2$ 表示，两样本方差分别用 $S_1$ 和 $S_2$ 表示。
-
-$$
-E(\hat{\mu}_1 - \hat{\mu}_2) = \mu_1 - \mu_2, \ \ Var(\hat{\mu}_1 - \hat{\mu}_2) = \frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}
-$$
+两样本均值分别用 $\hat{\mu}_1$ 和 $\hat{\mu}_2$ 表示，两样本方差分别用 $s_1$ 和 $s_2$ 表示，两总体方差分别用 $\sigma_1$ 和 $\sigma_2$ 表示。
 
 以下推导过程在边界条件 $\mu_1 = \mu_2$ 下进行。
 
-## Z 检验 {#z-test}
+## *z* 检验 {#z-test}
 
-大样本时，可使用 $Z$ 检验进行推导。
+### 假设两组方差相等 {#z-test-equal-var}
 
-### 方差相等 {#z-test-equal-variance}
-
-在 $H_0$ 成立时，可构建 $Z$ 统计量：
+令 $\sigma$ = $\sigma_1$ = $\sigma_2$，则：
 
 $$
-Z = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} \sim N(0, 1)
+\operatorname{SD}(\hat{\mu}_1 - \hat{\mu}_2) = \sigma \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}
 $$
 
-在 $H_1$ 成立时，可构建 $Z'$ 统计量：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
-Z' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} \sim N\left(\frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}, 1\right)
+z = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} \sim N(0, 1)
+$$
+
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
+
+$$
+z' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} \sim N\left(\frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}, 1\right)
 $$
 
 === "双侧检验"
 
     $$
-    \text{Power}
-    = P\left(Z' > z_{1-\alpha}\right) + P\left(Z' < z_{\alpha}\right)
-    = 1 - \Phi\left(z_{1-\alpha} - \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
-        + \Phi\left(z_{\alpha} - \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+      \text{Power}
+    = P\left(z' > z_{1-\alpha/2}\right) + P\left(z' < z_{\alpha/2}\right)
+    = 1 - \Phi\left(z_{1-\alpha/2} - \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+        + \Phi\left(z_{\alpha/2} - \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     $$
 
 === "左单侧检验"
 
     $$
-    \text{Power}
-    = P\left(Z' < z_{\alpha}\right)
+      \text{Power}
+    = P\left(z' < z_{\alpha}\right)
     = \Phi\left(z_{\alpha} - \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     = 1 - \Phi\left(z_{1-\alpha} + \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     $$
@@ -75,59 +74,61 @@ $$
 === "右单侧检验"
 
     $$
-    \text{Power}
-    = P\left(Z' > z_{1-\alpha}\right)
+      \text{Power}
+    = P\left(z' > z_{1-\alpha}\right)
     = 1 - \Phi\left(z_{1-\alpha} - \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     $$
 
-对于单侧检验，可利用功效函数得到样本量的闭式解：
+??? note "单侧检验样本量公式推导"
 
-根据标准正态分布分位数的定义：
+    根据标准正态分布分位数的定义：
 
-$$
-z_{1-\alpha} \pm \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} = z_\beta
-$$
+    $$
+    z_{1-\alpha} \pm \frac{\mu_1 - \mu_2}{\sigma\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} = z_\beta
+    $$
 
-设 $n_1 = kn_2$，由上式可解出
+    设 $n_1 = kn_2$，由上式可解出
 
-$$
-n_2 = \frac{\left(z_{1-\alpha} + z_{1-\beta}\right)^2 \sigma^2 \left(\frac{1}{k} + 1\right)}{\left(\mu_1 - \mu_2\right)^2}
-$$
+    $$
+    n_2 = \frac{\left(z_{1-\alpha} + z_{1-\beta}\right)^2 \sigma^2 \left(\frac{1}{k} + 1\right)}{\left(\mu_1 - \mu_2\right)^2}
+    $$
 
-$$
-n_1 = k n_2
-$$
+    $$
+    n_1 = k n_2
+    $$
 
-
-### 方差不相等 {#z-test-unequal-variance}
-
-
-在 $H_0$ 成立时，可构建 $Z$ 统计量：
+### 假设两组方差不等 {#z-test-unequal-var}
 
 $$
-Z = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} \sim N(0, 1)
+\operatorname{SD}(\hat{\mu}_1 - \hat{\mu}_2) = \sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}
 $$
 
-在 $H_1$ 成立时，可构建 $Z'$ 统计量：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
-Z' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} \sim N\left(\frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}, 1\right)
+z = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} \sim N(0, 1)
+$$
+
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
+
+$$
+z' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} \sim N\left(\frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}, 1\right)
 $$
 
 === "双侧检验"
 
     $$
-    \text{Power}
-    = P\left(Z' > z_{1-\alpha}\right) + P\left(Z' < z_{\alpha}\right)
-    = 1 - \Phi\left(z_{1-\alpha} - \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
-        + \Phi\left(z_{\alpha} - \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
+      \text{Power}
+    = P\left(z' > z_{1-\alpha/2}\right) + P\left(z' < z_{\alpha/2}\right)
+    = 1 - \Phi\left(z_{1-\alpha/2} - \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
+        + \Phi\left(z_{\alpha/2} - \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
     $$
 
 === "左单侧检验"
 
     $$
-    \text{Power}
-    = P\left(Z' < z_{\alpha}\right)
+      \text{Power}
+    = P\left(z' < z_{\alpha}\right)
     = \Phi\left(z_{\alpha} - \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
     = 1 - \Phi\left(z_{1-\alpha} + \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
     $$
@@ -135,64 +136,66 @@ $$
 === "右单侧检验"
 
     $$
-    \text{Power}
-    = P\left(Z' > z_{1-\alpha}\right)
+      \text{Power}
+    = P\left(z' > z_{1-\alpha}\right)
     = 1 - \Phi\left(z_{1-\alpha} - \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}}\right)
     $$
 
-对于单侧检验，可利用功效函数得到样本量的闭式解：
+??? note "单侧检验样本量公式推导"
 
-根据标准正态分布分位数的定义：
+    根据标准正态分布分位数的定义：
 
-$$
-z_{1-\alpha} \pm \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} = z_\beta
-$$
+    $$
+    z_{1-\alpha} \pm \frac{\mu_1 - \mu_2}{\sqrt{\frac{\sigma_1^2}{n_1} + \frac{\sigma_2^2}{n_2}}} = z_\beta
+    $$
 
-设 $n_1 = kn_2$，由上式可解出
+    设 $n_1 = kn_2$，由上式可解出
 
-$$
-n_2 = \frac{\left(z_{1-\alpha} + z_{1-\beta}\right)^2 \left(\frac{\sigma_1^2}{k} + \sigma_2^2\right)}{\left(\mu_1 - \mu_2\right)^2}
-$$
+    $$
+    n_2 = \frac{\left(z_{1-\alpha} + z_{1-\beta}\right)^2 \left(\frac{\sigma_1^2}{k} + \sigma_2^2\right)}{\left(\mu_1 - \mu_2\right)^2}
+    $$
 
-$$
-n_1 = k n_2
-$$
+    $$
+    n_1 = k n_2
+    $$
 
-## t 检验 {#t-test}
+## *t* 检验 {#t-test}
 
-小样本时，可使用 $t$ 检验进行推导。
+### 假设两组方差相等 {#t-test-equal-var}
 
-### 方差相等 {#t-test-equal-variance}
-
-当两总体方差相等时，即 $\sigma_1^2 = \sigma_2^2$ 时，可将样本方差合并，计算合并方差 $S_c^2$：
+当两组总体方差相等时，即 $\sigma_1^2 = \sigma_2^2$ 时，可计算合并方差 $s_c^2$ ：
 
 $$
-S_c^2 = \frac{(n_1 - 1)S_1^2 + (n_2 - 1)S_2^2}{n_1 + n_2 - 2}
+s_c^2 = \frac{(n_1-1)s_1^2 + (n_2-1)s_2^2}{n_1+n_2-2}
 $$
 
-在 $H_0$ 成立时，可构建 $T$ 统计量：
-
 $$
-T = \frac{\hat{\mu}_1 - \hat{\mu}_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} \sim t(n_1 + n_2 - 2)
+\operatorname{SD}(\hat{\mu}_1 - \hat{\mu}_2) = s_c \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}
 $$
 
-在 $H_1$ 成立时，可构建 $T'$ 统计量：
+在 $H_0$ 成立时，可构建 $t$ 统计量：
 
 $$
-T' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}
-   \sim t\left(n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+t = \frac{\hat{\mu}_1 - \hat{\mu}_2}{s_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}} \sim t(n_1 + n_2 - 2)
 $$
 
-令 $F(x;v,\lambda)$ 为自由度为 $v$、非中心参数为 $\lambda$ 的非中心 $t$ 分布的累积分布函数。
+在 $H_1$ 成立时，可构建 $t'$ 统计量：
+
+$$
+t' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{s_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}
+     \sim t\left(n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{\sigma \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+$$
+
+令 $T(x;v,\lambda)$ 为自由度为 $v$，非中心参数为 $\lambda$ 的非中心 $t$ 分布的累积分布函数。
 
 === "双侧检验"
 
     $$
     \begin{align}
         \text{Power}
-    & = P\left(T' > t_{1-\alpha}\right) + P\left(T' < t_{\alpha}\right) \\
-    & = 1 - F\left(t_{1-\alpha, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
-          + F\left(t_{\alpha, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+    & = P\left(t' > t_{1-\alpha/2}\right) + P\left(t' < t_{\alpha/2}\right) \\
+    & = 1 - T\left(t_{1-\alpha/2, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{\sigma \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+          + T\left(t_{\alpha/2, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{\sigma \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     \end{align}
     $$
 
@@ -200,53 +203,57 @@ $$
 
     $$
       \text{Power}
-    = P\left(T' < t_{\alpha}\right)
-    = F\left(t_{\alpha, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+    = P\left(t' < t_{\alpha}\right)
+    = T\left(t_{\alpha, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{\sigma \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     $$
 
 === "右单侧检验"
 
     $$
       \text{Power}
-    = P\left(T' > t_{1-\alpha}\right)
-    = 1 - F\left(t_{1-\alpha, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{S_c\sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
+    = P\left(t' > t_{1-\alpha}\right)
+    = 1 - T\left(t_{1-\alpha, n_1 + n_2 - 2}; n_1 + n_2 - 2, \frac{\mu_1 - \mu_2}{\sigma \sqrt{\frac{1}{n_1} + \frac{1}{n_2}}}\right)
     $$
 
-### 方差不相等 {#t-test-unequal-variance}
+### 假设两组方差不等 {#t-test-unequal-var}
+
+$$
+\operatorname{SD}(\hat{\mu}_1 - \hat{\mu}_2) = \sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}
+$$
 
 当两总体方差不相等时，即 $\sigma_1^2 \ne \sigma_2^2$ 时，可使用以下近似 $t$ 检验进行推导。
 
-#### Satterthwaite 近似 t 检验 {#t-test-unequal-variance-satterthwaite}
+#### Welch 近似 *t* 检验 {#t-test-unequal-var-welch}
 
-在 $H_0$ 成立时，可构建 $T$ 统计量：
+在 $H_0$ 成立时，可构建 $t$ 统计量：
 
 $$
-T = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}} \sim t(v')
+t = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}} \sim t(v')
 $$
 
 其中：
 
 $$
-v' = \frac{\left(\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}\right)^2}{\frac{S_1^4}{n_1^2(n_1 - 1)} + \frac{S_2^4}{n_2^2(n_2 - 1)}}
+v' = \frac{\left(\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}\right)^2}{\frac{s_1^4}{n_1^2(n_1 + 1)} + \frac{s_2^4}{n_2^2(n_2 + 1)}} - 2
 $$
 
-在 $H_1$ 成立时，可构建 $T'$ 统计量：
+在 $H_1$ 成立时，可构建 $t'$ 统计量：
 
 $$
-T' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}
-   \sim t\left(v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+t' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}
+     \sim t\left(v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
 $$
 
-令 $F(x;v,\lambda)$ 为自由度为 $v$、非中心参数为 $\lambda$ 的非中心 $t$ 分布的累积分布函数。
+令 $T(x;v,\lambda)$ 为自由度为 $v$，非中心参数为 $\lambda$ 的非中心 $t$ 分布的累积分布函数。
 
 === "双侧检验"
 
     $$
     \begin{align}
         \text{Power}
-    & = P\left(T' > t_{1-\alpha}\right) + P\left(T' < t_{\alpha}\right) \\
-    & = 1 - F\left(t_{1-\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
-          + F\left(t_{\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+    & = P\left(t' > t_{1-\alpha/2}\right) + P\left(t' < t_{\alpha/2}\right) \\
+    & = 1 - T\left(t_{1-\alpha/2, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
+          + T\left(t_{\alpha/2, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
     \end{align}
     $$
 
@@ -254,49 +261,49 @@ $$
 
     $$
       \text{Power}
-    = P\left(T' < t_{\alpha}\right)
-    = F\left(t_{\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+    = P\left(t' < t_{\alpha}\right)
+    = T\left(t_{\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
     $$
 
 === "右单侧检验"
 
     $$
       \text{Power}
-    = P\left(T' > t_{1-\alpha}\right)
-    = 1 - F\left(t_{1-\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+    = P\left(t' > t_{1-\alpha}\right)
+    = 1 - T\left(t_{1-\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
     $$
 
-#### Welch 近似 t 检验 {#t-test-unequal-variance-welch}
+#### Satterthwaite 近似 *t* 检验 {#t-test-unequal-var-satterthwaite}
 
-在 $H_0$ 成立时，可构建 $T$ 统计量：
+在 $H_0$ 成立时，可构建 $t$ 统计量：
 
 $$
-T = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}} \sim t(v')
+t = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}} \sim t(v')
 $$
 
 其中：
 
 $$
-v' = \frac{\left(\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}\right)^2}{\frac{S_1^4}{n_1^2(n_1 + 1)} + \frac{S_2^4}{n_2^2(n_2 + 1)}} - 2
+v' = \frac{\left(\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}\right)^2}{\frac{s_1^4}{n_1^2(n_1 - 1)} + \frac{s_2^4}{n_2^2(n_2 - 1)}}
 $$
 
-在 $H_1$ 成立时，可构建 $T'$ 统计量：
+在 $H_1$ 成立时，可构建 $t'$ 统计量：
 
 $$
-T' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}
-   \sim t\left(v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+t' = \frac{\hat{\mu}_1 - \hat{\mu}_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}
+     \sim t\left(v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
 $$
 
-令 $F(x;v,\lambda)$ 为自由度为 $v$、非中心参数为 $\lambda$ 的非中心 $t$ 分布的累积分布函数。
+令 $T(x;v,\lambda)$ 为自由度为 $v$，非中心参数为 $\lambda$ 的非中心 $t$ 分布的累积分布函数。
 
 === "双侧检验"
 
     $$
     \begin{align}
         \text{Power}
-    & = P\left(T' > t_{1-\alpha}\right) + P\left(T' < t_{\alpha}\right) \\
-    & = 1 - F\left(t_{1-\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
-          + F\left(t_{\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+    & = P\left(t' > t_{1-\alpha/2}\right) + P\left(t' < t_{\alpha/2}\right) \\
+    & = 1 - T\left(t_{1-\alpha/2, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
+          + T\left(t_{\alpha/2, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
     \end{align}
     $$
 
@@ -304,14 +311,14 @@ $$
 
     $$
       \text{Power}
-    = P\left(T' < t_{\alpha}\right)
-    = F\left(t_{\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+    = P\left(t' < t_{\alpha}\right)
+    = T\left(t_{\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
     $$
 
 === "右单侧检验"
 
     $$
       \text{Power}
-    = P\left(T' > t_{1-\alpha}\right)
-    = 1 - F\left(t_{1-\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{S_1^2}{n_1} + \frac{S_2^2}{n_2}}}\right)
+    = P\left(t' > t_{1-\alpha}\right)
+    = 1 - T\left(t_{1-\alpha, v'}; v', \frac{\mu_1 - \mu_2}{\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}\right)
     $$


### PR DESCRIPTION
### **PR Type**
Documentation, Bug fix


___

### **Description**
- Fix critical values for two-sided tests to use α/2 quantiles

- Correct variance notation: sample variance s², population variance σ²

- Swap and fix Welch and Satterthwaite degrees-of-freedom formulas

- Replace noncentral t CDF notation from F to T

- Add standard deviation expressions for clarity

- Move sample size derivations into collapsible notes

- Polish headings and LaTeX formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Introduction & Hypotheses"] -- "z-test" --> B["z-test sections"]
  B -- "equal var" --> C1["Equal variance formulas"]
  B -- "unequal var" --> C2["Unequal variance formulas"]
  A -- "t-test" --> D["t-test sections"]
  D -- "equal var" --> E1["Pooled variance (standard)"]
  D -- "unequal var" --> E2["Two approximations"]
  E2 -- "Welch" --> F1["Welch df (standard)"]
  E2 -- "Satterthwaite" --> F2["Satterthwaite df (alt)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inequality.md</strong><dd><code>Fix formulas, notation and structure for independent mean inequality </code><br><code>doc</code></dd></summary>
<hr>

docs/algorithms/mean/independent/inequality.md

<ul><li>Corrected two‑sided test quantiles from z₁₋α to z₁₋α/2 (and similarly <br>for t)<br> <li> Fixed sample/population variance notation and added SD expressions<br> <li> Swapped Welch and Satterthwaite section order and corrected their df <br>formulas<br> <li> Changed noncentral t CDF symbol from F to T for clarity<br> <li> Moved sample‑size derivations into collapsible note blocks<br> <li> Improved heading hierarchy and LaTeX consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/435/files#diff-478dbfb3cc3d57913fc140167df02009564b352e0086c9692d263ee0fc959b7c">+115/-108</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

