### PR TITLE
test: add markers dynamically

### DIFF
--- a/tests/test_mean/test_independent/test_inequality.py
+++ b/tests/test_mean/test_independent/test_inequality.py
@@ -692,7 +692,7 @@ def test_solve_power_errors() -> None:
         solve_power(treatment_mean=40, reference_mean=30, diff=None, treatment_std=40, reference_std=30, treatment_size=100, reference_size=100, method="z", equal_var=True)
 
 
-def test_solve_size(case: TestCase) -> None:
+def test_solve_size(case: TestCase, request: pytest.FixtureRequest) -> None:
     if (
         case
         in [
@@ -719,7 +719,7 @@ def test_solve_size(case: TestCase) -> None:
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     ratio = case.treatment_size / case.reference_size
     assert solve_size(
@@ -738,13 +738,13 @@ def test_solve_size(case: TestCase) -> None:
     ) == (case.treatment_size, case.reference_size)
 
 
-def test_solve_diff(case: TestCase) -> None:
+def test_solve_diff(case: TestCase, request: pytest.FixtureRequest) -> None:
     if (
         case == TestCase(treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     search_direction = "above" if case.diff > 0 else "below"
     assert (
@@ -768,13 +768,13 @@ def test_solve_diff(case: TestCase) -> None:
     )
 
 
-def test_solve_treatment_mean(case: TestCase) -> None:
+def test_solve_treatment_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if (
         case == TestCase(treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     search_direction = "above" if case.treatment_mean > case.reference_mean else "below"
     assert (
@@ -799,13 +799,13 @@ def test_solve_treatment_mean(case: TestCase) -> None:
     )
 
 
-def test_solve_reference_mean(case: TestCase) -> None:
+def test_solve_reference_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if (
         case == TestCase(treatment_mean=56, reference_mean=30, diff=26, treatment_std=40, reference_std=40, treatment_size=45, reference_size=23, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8065, method="t", equal_var=True)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and case.equal_var)
         or (case.treatment_mean in range(40, 61) and case.alternative == "two-sided" and case.method == "t" and not case.equal_var)
     ):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     search_direction = "above" if case.reference_mean > case.treatment_mean else "below"
     assert (

--- a/tests/test_mean/test_independent/test_noninferiority.py
+++ b/tests/test_mean/test_independent/test_noninferiority.py
@@ -434,7 +434,7 @@ def test_solve_power(case: TestCase) -> None:
     ) == round(case.actual_power, 4)
 
 
-def test_solve_size(case: TestCase) -> None:
+def test_solve_size(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(treatment_mean=10, reference_mean=10, margin=-17, treatment_std=40, reference_std=40, treatment_size=131, reference_size=66, alternative="greater", alpha=0.025, power=0.8, actual_power=0.8, dist="t", equal_var=True),
         TestCase(treatment_mean=10, reference_mean=10, margin=-12, treatment_std=40, reference_std=40, treatment_size=263, reference_size=132, alternative="greater", alpha=0.025, power=0.8, actual_power=0.8011, dist="t", equal_var=True),
@@ -503,7 +503,7 @@ def test_solve_size(case: TestCase) -> None:
             approx_t_method="welch",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     ratio = case.treatment_size / case.reference_size
     assert solve_size(
@@ -523,7 +523,7 @@ def test_solve_size(case: TestCase) -> None:
     ) == (case.treatment_size, case.reference_size)
 
 
-def test_solve_treatment_mean(case: TestCase) -> None:
+def test_solve_treatment_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=10,
@@ -558,7 +558,7 @@ def test_solve_treatment_mean(case: TestCase) -> None:
             approx_t_method="satterthwaite",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -583,7 +583,7 @@ def test_solve_treatment_mean(case: TestCase) -> None:
     )
 
 
-def test_solve_reference_mean(case: TestCase) -> None:
+def test_solve_reference_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=10,
@@ -618,7 +618,7 @@ def test_solve_reference_mean(case: TestCase) -> None:
             approx_t_method="satterthwaite",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -643,7 +643,7 @@ def test_solve_reference_mean(case: TestCase) -> None:
     )
 
 
-def test_solve_diff(case: TestCase) -> None:
+def test_solve_diff(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(treatment_mean=10, reference_mean=10, margin=-14, treatment_std=40, reference_std=40, treatment_size=193, reference_size=97, alternative="greater", alpha=0.025, power=0.8, actual_power=0.8003, dist="t", equal_var=True),
         TestCase(
@@ -695,7 +695,7 @@ def test_solve_diff(case: TestCase) -> None:
             approx_t_method="satterthwaite",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -719,7 +719,7 @@ def test_solve_diff(case: TestCase) -> None:
     )
 
 
-def test_solve_margin(case: TestCase) -> None:
+def test_solve_margin(case: TestCase, request: pytest.FixtureRequest) -> None:
 
     if case in [
         TestCase(treatment_mean=10, reference_mean=10, margin=-14, treatment_std=40, reference_std=40, treatment_size=193, reference_size=97, alternative="greater", alpha=0.025, power=0.8, actual_power=0.8003, dist="t", equal_var=True),
@@ -788,7 +788,7 @@ def test_solve_margin(case: TestCase) -> None:
             approx_t_method="satterthwaite",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(

--- a/tests/test_mean/test_independent/test_superiority.py
+++ b/tests/test_mean/test_independent/test_superiority.py
@@ -377,7 +377,7 @@ def test_solve_power(case: TestCase) -> None:
     ) == round(case.actual_power, 4)
 
 
-def test_solve_size(case: TestCase) -> None:
+def test_solve_size(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=40,
@@ -444,7 +444,7 @@ def test_solve_size(case: TestCase) -> None:
             approx_t_method="satterthwaite",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     ratio = case.treatment_size / case.reference_size
     assert solve_size(
@@ -465,7 +465,7 @@ def test_solve_size(case: TestCase) -> None:
     ) == (case.treatment_size, case.reference_size)
 
 
-def test_solve_treatment_mean(case: TestCase) -> None:
+def test_solve_treatment_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=40,
@@ -484,7 +484,7 @@ def test_solve_treatment_mean(case: TestCase) -> None:
             approx_t_method="welch",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -509,7 +509,7 @@ def test_solve_treatment_mean(case: TestCase) -> None:
     )
 
 
-def test_solve_reference_mean(case: TestCase) -> None:
+def test_solve_reference_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=40,
@@ -528,7 +528,7 @@ def test_solve_reference_mean(case: TestCase) -> None:
             approx_t_method="welch",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -553,7 +553,7 @@ def test_solve_reference_mean(case: TestCase) -> None:
     )
 
 
-def test_solve_diff(case: TestCase) -> None:
+def test_solve_diff(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=40,
@@ -604,7 +604,7 @@ def test_solve_diff(case: TestCase) -> None:
             approx_t_method="satterthwaite",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -628,7 +628,7 @@ def test_solve_diff(case: TestCase) -> None:
     )
 
 
-def test_solve_margin(case: TestCase) -> None:
+def test_solve_margin(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(
             treatment_mean=40,
@@ -647,7 +647,7 @@ def test_solve_margin(case: TestCase) -> None:
             approx_t_method="welch",
         ),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(

--- a/tests/test_mean/test_single/test_inequality.py
+++ b/tests/test_mean/test_single/test_inequality.py
@@ -140,7 +140,7 @@ def test_solve_power(case: TestCase) -> None:
     )
 
 
-def test_solve_size(case: TestCase) -> None:
+def test_solve_size(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=20, mean=40, std=20, size=8, alternative="greater", alpha=0.05, power=0.8, actual_power=0.815, method="t"),
         TestCase(null_mean=20, mean=30, std=20, size=34, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8078, method="t"),
@@ -155,11 +155,11 @@ def test_solve_size(case: TestCase) -> None:
         TestCase(null_mean=20, mean=39, std=20, size=11, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.81, method="t"),
         TestCase(null_mean=20, mean=40, std=20, size=10, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8031, method="t"),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
     assert solve_size(null_mean=case.null_mean, mean=case.mean, std=case.std, alternative=case.alternative, alpha=case.alpha, power=case.power, method=case.method) == case.size
 
 
-def test_solve_null_mean(case: TestCase) -> None:
+def test_solve_null_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=20, mean=33, std=20, size=17, alternative="greater", alpha=0.05, power=0.8, actual_power=0.821, method="t"),
         TestCase(null_mean=20, mean=34, std=20, size=15, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8243, method="t"),
@@ -176,7 +176,7 @@ def test_solve_null_mean(case: TestCase) -> None:
         TestCase(null_mean=20, mean=39, std=20, size=11, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.81, method="t"),
         TestCase(null_mean=20, mean=40, std=20, size=10, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8031, method="t"),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     search_direction = "below" if case.null_mean < case.mean else "above"
     assert (
@@ -188,7 +188,7 @@ def test_solve_null_mean(case: TestCase) -> None:
     )
 
 
-def test_solve_mean(case: TestCase) -> None:
+def test_solve_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=20, mean=33, std=20, size=17, alternative="greater", alpha=0.05, power=0.8, actual_power=0.821, method="t"),
         TestCase(null_mean=20, mean=34, std=20, size=15, alternative="greater", alpha=0.05, power=0.8, actual_power=0.8243, method="t"),
@@ -205,7 +205,7 @@ def test_solve_mean(case: TestCase) -> None:
         TestCase(null_mean=20, mean=39, std=20, size=11, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.81, method="t"),
         TestCase(null_mean=20, mean=40, std=20, size=10, alternative="two-sided", alpha=0.05, power=0.8, actual_power=0.8031, method="t"),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     search_direction = "below" if case.mean < case.null_mean else "above"
     assert (

--- a/tests/test_mean/test_single/test_noninferiority.py
+++ b/tests/test_mean/test_single/test_noninferiority.py
@@ -134,13 +134,13 @@ def test_solve_power_raise_error() -> None:
         solve_power(null_mean=None, mean=None, diff=None, margin=-2, std=5, size=20, alternative="greater", alpha=0.025)
 
 
-def test_solve_size(case: TestCase) -> None:
+def test_solve_size(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=0, margin=-5.0, std=10, size=34, alternative="greater", alpha=0.025, power=0.80, actual_power=0.807776686),
         TestCase(null_mean=None, mean=None, diff=0, margin=-3.5, std=10, size=67, alternative="greater", alpha=0.025, power=0.80, actual_power=0.805928876),
         TestCase(null_mean=None, mean=None, diff=0, margin=-2.5, std=10, size=128, alternative="greater", alpha=0.025, power=0.80, actual_power=0.801506203),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     if (
         case
@@ -149,13 +149,14 @@ def test_solve_size(case: TestCase) -> None:
         ]
         and sys.platform == "darwin"
     ):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     if case in [
         TestCase(null_mean=None, mean=None, diff=0, margin=-1.0, std=10, size=786, alternative="greater", alpha=0.025, power=0.80, actual_power=0.800441366),
         TestCase(null_mean=None, mean=None, diff=0, margin=-0.5, std=10, size=3140, alternative="greater", alpha=0.025, power=0.80, actual_power=0.800027594),
     ]:
-        pytest.skip(reason="There may be issues with the PASS calculation results, so the test is temporarily skipped")
+        request.node.add_marker(pytest.skip(reason="There may be issues with the PASS calculation results, so the test is temporarily skipped"))
+
     assert (
         solve_size(
             null_mean=case.null_mean,
@@ -215,7 +216,7 @@ def test_solve_diff(case: TestCase) -> None:
     )
 
 
-def test_solve_null_mean(case: TestCase) -> None:
+def test_solve_null_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
 
     if case.mean is None and case.null_mean is None and case.diff is not None:
         null_mean = case.size
@@ -224,7 +225,7 @@ def test_solve_null_mean(case: TestCase) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=0, margin=-6.0, std=10, size=24, alternative="greater", alpha=0.025, power=0.80, actual_power=0.803670529),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert round(
         solve_null_mean(
@@ -240,7 +241,7 @@ def test_solve_null_mean(case: TestCase) -> None:
     ) == round(null_mean, 2)
 
 
-def test_solve_mean(case: TestCase) -> None:
+def test_solve_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
 
     if case.mean is None and case.null_mean is None and case.diff is not None:
         null_mean = case.size
@@ -249,7 +250,7 @@ def test_solve_mean(case: TestCase) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=0, margin=-6.0, std=10, size=24, alternative="greater", alpha=0.025, power=0.80, actual_power=0.803670529),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert round(
         solve_mean(
@@ -314,12 +315,12 @@ def test_solve_std_raise_error() -> None:
         solve_std(null_mean=None, mean=None, diff=None, margin=-2, size=20, alternative="greater", alpha=0.025, power=0.8)
 
 
-def test_solve_margin(case: TestCase) -> None:
+def test_solve_margin(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=0, margin=-7.0, std=10, size=19, alternative="greater", alpha=0.025, power=0.80, actual_power=0.822546679),
         TestCase(null_mean=None, mean=None, diff=0, margin=-6.0, std=10, size=24, alternative="greater", alpha=0.025, power=0.80, actual_power=0.803670529),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(

--- a/tests/test_mean/test_single/test_superiority.py
+++ b/tests/test_mean/test_single/test_superiority.py
@@ -130,11 +130,11 @@ def test_solve_power_raise_error() -> None:
         solve_power(null_mean=None, mean=None, diff=None, margin=2, std=5, size=20, alternative="greater", alpha=0.025)
 
 
-def test_solve_size(case: TestCase) -> None:
+def test_solve_size(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=7.5, std=15, size=34, alternative="greater", alpha=0.025, power=0.80, actual_power=0.807776686),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     if (
         case
@@ -143,7 +143,7 @@ def test_solve_size(case: TestCase) -> None:
         ]
         and sys.platform == "darwin"
     ):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         solve_size(
@@ -187,11 +187,11 @@ def test_solve_size_raise_error() -> None:
         solve_size(null_mean=None, mean=None, diff=None, margin=2, std=5, alternative="greater", alpha=0.025, power=0.8)
 
 
-def test_solve_diff(case: TestCase) -> None:
+def test_solve_diff(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=1.5, std=15, size=12, alternative="greater", alpha=0.025, power=0.80, actual_power=0.809784845),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(
@@ -209,7 +209,7 @@ def test_solve_diff(case: TestCase) -> None:
     )
 
 
-def test_solve_null_mean(case: TestCase) -> None:
+def test_solve_null_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
 
     if case.mean is None and case.null_mean is None and case.diff is not None:
         null_mean = case.size
@@ -218,12 +218,12 @@ def test_solve_null_mean(case: TestCase) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=9.5, std=15, size=61, alternative="greater", alpha=0.025, power=0.80, actual_power=0.804464986),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=3.5, std=15, size=16, alternative="greater", alpha=0.025, power=0.80, actual_power=0.817438156),
     ] and sys.platform in ("linux", "darwin"):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert round(
         solve_null_mean(
@@ -239,7 +239,7 @@ def test_solve_null_mean(case: TestCase) -> None:
     ) == round(null_mean, 2)
 
 
-def test_solve_mean(case: TestCase) -> None:
+def test_solve_mean(case: TestCase, request: pytest.FixtureRequest) -> None:
 
     if case.mean is None and case.null_mean is None and case.diff is not None:
         null_mean = case.size
@@ -248,12 +248,12 @@ def test_solve_mean(case: TestCase) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=9.5, std=15, size=61, alternative="greater", alpha=0.025, power=0.80, actual_power=0.804464986),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=3.5, std=15, size=16, alternative="greater", alpha=0.025, power=0.80, actual_power=0.817438156),
     ] and sys.platform in ("linux", "darwin"):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert round(
         solve_mean(
@@ -318,16 +318,16 @@ def test_solve_std_raise_error() -> None:
         solve_std(null_mean=None, mean=None, diff=None, margin=2, size=20, alternative="greater", alpha=0.025, power=0.8)
 
 
-def test_solve_margin(case: TestCase) -> None:
+def test_solve_margin(case: TestCase, request: pytest.FixtureRequest) -> None:
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=9.5, std=15, size=61, alternative="greater", alpha=0.025, power=0.80, actual_power=0.804464986),
     ]:
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     if case in [
         TestCase(null_mean=None, mean=None, diff=15, margin=3.5, std=15, size=16, alternative="greater", alpha=0.025, power=0.80, actual_power=0.817438156),
     ] and sys.platform in ("linux", "darwin"):
-        pytest.xfail("SciPy upstream bug: https://github.com/scipy/scipy/issues/25106")
+        request.node.add_marker(pytest.mark.xfail(reason="SciPy upstream bug: https://github.com/scipy/scipy/issues/25106"))
 
     assert (
         round(


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Replace direct `pytest.xfail`/`pytest.skip` calls with dynamic marker addition via `request.node.add_marker`

- Add `request: pytest.FixtureRequest` parameter to test functions that conditionally mark tests

- Retain the same reasons for expected failures and skips (Scipy upstream bugs, PASS calculation issues)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test functions (e.g., test_solve_size)"] -- "add parameter" --> B["request: pytest.FixtureRequest"]
  B -- "replace direct call" --> C["request.node.add_marker(pytest.mark.xfail/reason=...)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_inequality.py</strong><dd><code>Dynamically apply xfail markers in independent two-sample inequality </code><br><code>tests</code></dd></summary>
<hr>

tests/test_mean/test_independent/test_inequality.py

<ul><li>Added <code>request</code> parameter to <code>test_solve_size</code>, <code>test_solve_diff</code>, <br><code>test_solve_treatment_mean</code>, <code>test_solve_reference_mean</code><br> <li> Replaced <code>pytest.xfail(...)</code> with <br><code>request.node.add_marker(pytest.mark.xfail(reason=...))</code> for SciPy <br>upstream bug</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/440/files#diff-e8783d8c3ac2cc8a167db5cbc51915150a3ebb630d86cf445fc68b706bb90c34">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_noninferiority.py</strong><dd><code>Dynamically apply xfail markers in independent two-sample </code><br><code>noninferiority tests</code></dd></summary>
<hr>

tests/test_mean/test_independent/test_noninferiority.py

<ul><li>Added <code>request</code> parameter to <code>test_solve_size</code>, <code>test_solve_treatment_mean</code>, <br><code>test_solve_reference_mean</code>, <code>test_solve_diff</code>, <code>test_solve_margin</code><br> <li> Replaced <code>pytest.xfail(...)</code> with <br><code>request.node.add_marker(pytest.mark.xfail(reason=...))</code> for SciPy <br>upstream bug</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/440/files#diff-6abd5e288ff67dc2e66fea263b37b06184a3840a4af3ab00f3eeb4d5e8da4f9b">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_superiority.py</strong><dd><code>Dynamically apply xfail markers in independent two-sample superiority </code><br><code>tests</code></dd></summary>
<hr>

tests/test_mean/test_independent/test_superiority.py

<ul><li>Added <code>request</code> parameter to <code>test_solve_size</code>, <code>test_solve_treatment_mean</code>, <br><code>test_solve_reference_mean</code>, <code>test_solve_diff</code>, <code>test_solve_margin</code><br> <li> Replaced <code>pytest.xfail(...)</code> with <br><code>request.node.add_marker(pytest.mark.xfail(reason=...))</code> for SciPy <br>upstream bug</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/440/files#diff-c7f16c1716107659f3b80fd48cfa8173125ccf6ac0eb2c2d4c9455e3d2fca210">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_inequality.py</strong><dd><code>Dynamically apply xfail markers in single-sample inequality tests</code></dd></summary>
<hr>

tests/test_mean/test_single/test_inequality.py

<ul><li>Added <code>request</code> parameter to <code>test_solve_size</code>, <code>test_solve_null_mean</code>, <br><code>test_solve_mean</code><br> <li> Replaced <code>pytest.xfail(...)</code> with <br><code>request.node.add_marker(pytest.mark.xfail(reason=...))</code> for SciPy <br>upstream bug</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/440/files#diff-93de78dd8b5486f5b5a25a49b96179d6beaa6c21521b08344846515d0cb561a6">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_noninferiority.py</strong><dd><code>Dynamically apply xfail/skip markers in single-sample noninferiority </code><br><code>tests</code></dd></summary>
<hr>

tests/test_mean/test_single/test_noninferiority.py

<ul><li>Added <code>request</code> parameter to <code>test_solve_size</code>, <code>test_solve_null_mean</code>, <br><code>test_solve_mean</code>, <code>test_solve_margin</code><br> <li> Replaced <code>pytest.xfail(...)</code> with <br><code>request.node.add_marker(pytest.mark.xfail(reason=...))</code><br> <li> Replaced one <code>pytest.skip(...)</code> with <br><code>request.node.add_marker(pytest.mark.skip(reason=...))</code> for PASS <br>calculation issue</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/440/files#diff-6a2ebd3416b8ac5b6cf2d719cd060a330045d5e6cf64b7387848153bbbae8814">+11/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_superiority.py</strong><dd><code>Dynamically apply xfail markers in single-sample superiority tests</code></dd></summary>
<hr>

tests/test_mean/test_single/test_superiority.py

<ul><li>Added <code>request</code> parameter to <code>test_solve_size</code>, <code>test_solve_diff</code>, <br><code>test_solve_null_mean</code>, <code>test_solve_mean</code>, <code>test_solve_margin</code><br> <li> Replaced <code>pytest.xfail(...)</code> with <br><code>request.node.add_marker(pytest.mark.xfail(reason=...))</code> for SciPy <br>upstream bug</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/440/files#diff-691545b8f2f5b895519a1d3408f9de1dbf4c32809850f296ad41b1f0aa95454e">+14/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

