### PR TITLE
ci: trigger labeler only on PR opened event

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 name: "Pull Request Labeler"
 
 on:
-  - pull_request_target
+  pull_request_target:
+    types: [opened]
 
 jobs:
   labeler:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Trigger labeler only on PR opened event

- Stop labeler from running on PR updates


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>labeler.yml</strong><dd><code>Limit labeler to opened PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/labeler.yml

<ul><li>Changed <code>pull_request_target</code> trigger to only run for <code>types: [opened]</code><br> <li> Avoids labeler runs on PR synchronize, reopen, etc.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/444/files#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

