### PR TITLE
ci: add full pytest with scipy 1.18.0

### DIFF
--- a/.github/workflows/pytest_full.yml
+++ b/.github/workflows/pytest_full.yml
@@ -23,12 +23,12 @@ jobs:
             for v in $(seq 7 15); do echo "{\"python\":\"3.10\",\"scipy\":\"1.$v\"}"; done
             # Py 3.11: 1.10 ~ 1.17
             for v in $(seq 10 17); do echo "{\"python\":\"3.11\",\"scipy\":\"1.$v\"}"; done
-            # Py 3.12: 1.11 ~ 1.17
-            for v in $(seq 11 17); do echo "{\"python\":\"3.12\",\"scipy\":\"1.$v\"}"; done
-            # Py 3.13: 1.15 ~ 1.17
-            for v in $(seq 15 17); do echo "{\"python\":\"3.13\",\"scipy\":\"1.$v\"}"; done
-            # Py 3.14: 1.16 ~ 1.17
-            for v in $(seq 16 17); do echo "{\"python\":\"3.14\",\"scipy\":\"1.$v\"}"; done
+            # Py 3.12: 1.11 ~ 1.18
+            for v in $(seq 11 18); do echo "{\"python\":\"3.12\",\"scipy\":\"1.$v\"}"; done
+            # Py 3.13: 1.15 ~ 1.18
+            for v in $(seq 15 18); do echo "{\"python\":\"3.13\",\"scipy\":\"1.$v\"}"; done
+            # Py 3.14: 1.16 ~ 1.18
+            for v in $(seq 16 18); do echo "{\"python\":\"3.14\",\"scipy\":\"1.$v\"}"; done
           ) | jq -sc '{"include": .}' )
 
           echo "matrix=$JSON_STUFF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Include scipy 1.18.0 in full pytest matrix for Python 3.12, 3.13, and 3.14.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Current scipy ranges"] --> B["Updated ranges include 1.18.0"] --> C["Python 3.12, 3.13, 3.14"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pytest_full.yml</strong><dd><code>Update scipy version ranges to include 1.18.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pytest_full.yml

<ul><li>Updated comment and loop end for Python 3.12 to include scipy 1.18.<br> <li> Updated comment and loop end for Python 3.13 to include scipy 1.18.<br> <li> Updated comment and loop end for Python 3.14 to include scipy 1.18.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/455/files#diff-9e020cc2d5d70aa55ec61cc5be304df93b229cd6fd2bd9e0b3ddac4f0c535291">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

