### PR TITLE
refactor(mean.single.ci): rename functions and params, optimize the docstring

### DIFF
--- a/src/pystatpower/mean/single/ci.py
+++ b/src/pystatpower/mean/single/ci.py
@@ -4,148 +4,199 @@ from typing import Literal
 from scipy.optimize import brentq
 from scipy.stats import norm, t
 
-from ..._constant import SAMPLE_SIZE_SEARCH_MAX
 
-
-def _ci_half_width_z(
-    std: float, size: float, conf_level: float, interval_type: Literal["one-sided", "two-sided"]
-) -> float:
-    """Calculate the half-width of the confidence interval for one mean using z-test."""
-
-    match interval_type:
-        case "one-sided":
-            ci_half_width = norm.ppf(conf_level) * std / sqrt(size)
-        case "two-sided":
-            ci_half_width = norm.ppf((1 + conf_level) / 2) * std / sqrt(size)
-
-    return float(ci_half_width)
-
-
-def _ci_half_width_t(
-    std: float, size: float, conf_level: float, interval_type: Literal["one-sided", "two-sided"]
-) -> float:
-    """Calculate the half-width of the confidence interval for one mean using t-test."""
-
-    match interval_type:
-        case "one-sided":
-            ci_half_width = t.ppf(conf_level, size - 1) * std / sqrt(size)
-        case "two-sided":
-            ci_half_width = t.ppf((1 + conf_level) / 2, size - 1) * std / sqrt(size)
-
-    return float(ci_half_width)
-
-
-def _ci_half_width(
+def _precision_z(
     std: float,
     size: float,
     conf_level: float,
-    interval_type: Literal["one-sided", "two-sided"],
-    method: Literal["z", "t"],
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"],
 ) -> float:
-    """Calculate the half-width of the confidence interval for one mean."""
+    """Calculate the distance from the single-group mean to the confidence limit (commonly known as precision) using the z-distribution"""
 
-    match method:
+    alpha = 1 - conf_level
+
+    se = std / sqrt(size)
+
+    match interval_type:
+        case "two-sided":
+            precision = norm.ppf(1 - alpha / 2) * se
+        case "one-sided" | "lower" | "upper":
+            precision = norm.ppf(1 - alpha) * se
+
+    return float(precision)
+
+
+def _precision_t(
+    std: float,
+    size: float,
+    conf_level: float,
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"],
+) -> float:
+    """Calculate the distance from the single-group mean to the confidence limit (commonly known as precision) using the t-distribution."""
+
+    alpha = 1 - conf_level
+
+    se = std / sqrt(size)
+    df = size - 1
+
+    match interval_type:
+        case "two-sided":
+            precision = t.ppf(1 - alpha / 2, df) * se
+        case "one-sided":
+            precision = t.ppf(1 - alpha, df) * se
+
+    return float(precision)
+
+
+def _precision(
+    std: float,
+    size: float,
+    conf_level: float,
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"],
+    dist: Literal["z", "t"],
+) -> float:
+    """Calculate the distance from the single-group mean to the confidence limit (commonly known as precision)."""
+
+    match dist:
         case "z":
-            ci_half_width = _ci_half_width_z(std, size, conf_level, interval_type)
+            return _precision_z(std, size, conf_level, interval_type)
         case "t":
-            ci_half_width = _ci_half_width_t(std, size, conf_level, interval_type)
-
-    return float(ci_half_width)
+            return _precision_t(std, size, conf_level, interval_type)
 
 
-def solve_half_width(
+def solve_precision(
     *,
     std: float,
     size: int,
     conf_level: float = 0.95,
-    interval_type: Literal["one-sided", "two-sided"] = "two-sided",
-    method: Literal["z", "t"] = "t",
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"] = "two-sided",
+    dist: Literal["z", "t"] = "t",
 ) -> float:
     """
-    Calculate the half-width of the confidence interval for one mean.
+    Calculate the distance from the single-group mean to the confidence limit (commonly known as precision).
 
     Args:
-        std (float):
-            Standard deviation ($\\sigma$). If `method='t'`, provide the sample standard deviation ($S$).
-        size (int):
-            Sample size ($n$).
-        conf_level (float, Optional):
+        std:
+            Standard deviation.
+        size:
+            Sample size.
+        conf_level:
             Confidence level.
-        interval_type (Literal["one-sided", "two-sided"], optional):
+
+            - If `interval_type` is `'two-sided'`, a two-sided confidence level should be specified
+            - If `interval_type` is `'one-sided'`, `'lower'` or `'upper'`, a one-sided confidence level should be specified
+        interval_type:
             The type of confidence interval.
-        method (Literal["z", "t"], optional):
+
+            - `'two-sided'`: Two-sided confidence interval $(L, U)$.
+            - `'one-sided'`: One-sided confidence interval $(L, +\infty)$ or $(-\infty, U)$.
+            - `'lower'`: Lower one-sided confidence interval $(L, +\infty)$.
+            - `'upper'`: Upper one-sided confidence interval $(-\infty, U)$.
+        dist:
             The distribution used to construct the confidence interval.
 
+            - `'z'`: Normal distribution.
+            - `'t'`: Student's t-distribution.
+
     Returns:
-        (float): The half-width of the confidence interval for one mean.
+        float: The distance from the single-group mean to the confidence limit (commonly known as precision).
+
+    Notes:
+        Since the confidence interval for the single-group mean is symmetric, specifying `interval_type` as `'lower'`, `'upper'`, or `'one-sided'` works consistently.
     """
 
-    half_width = _ci_half_width(std, size, conf_level, interval_type, method)
-    return float(half_width)
+    return _precision(std, size, conf_level, interval_type, dist)
 
 
 def solve_size(
     *,
-    half_width: float,
+    precision: float,
     std: float,
     conf_level: float = 0.95,
-    interval_type: Literal["one-sided", "two-sided"] = "two-sided",
-    method: Literal["z", "t"] = "t",
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"] = "two-sided",
+    dist: Literal["z", "t"] = "t",
 ) -> int:
     """
-    Calculate the required sample size for the half-width of one mean confidence interval.
+    Estimate the required sample size, given the distance from the single-group mean to the confidence limit (commonly known as precision).
 
     Args:
-        half_width (float):
-            Half-width of the confidence interval ($d$).
-        std (float):
-            Standard deviation ($\\sigma$). If `method='t'`, provide the sample standard deviation ($S$).
-        conf_level (float, Optional):
+        precision:
+            Distance from the single-group mean to the confidence limit.
+        std:
+            Standard deviation.
+        conf_level:
             Confidence level.
-        interval_type (Literal["one-sided", "two-sided"], optional):
+
+            - If `interval_type` is `'two-sided'`, a two-sided confidence level should be specified
+            - If `interval_type` is `'one-sided'`, `'lower'` or `'upper'`, a one-sided confidence level should be specified
+        interval_type:
             The type of confidence interval.
-        method (Literal["z", "t"], optional):
+
+            - `'two-sided'`: Two-sided confidence interval $(L, U)$.
+            - `'one-sided'`: One-sided confidence interval $(L, +\infty)$ or $(-\infty, U)$.
+            - `'lower'`: Lower one-sided confidence interval $(L, +\infty)$.
+            - `'upper'`: Upper one-sided confidence interval $(-\infty, U)$.
+        dist:
             The distribution used to construct the confidence interval.
 
+            - `'z'`: Normal distribution.
+            - `'t'`: Student's t-distribution.
+
     Returns:
-        (int): The required sample size.
+        int: The required sample size.
+
+    Notes:
+        Since the confidence interval for the single-group mean is symmetric, specifying `interval_type` as `'lower'`, `'upper'`, or `'one-sided'` works consistently.
     """
 
     def func(size: float) -> float:
-        return _ci_half_width(std, size, conf_level, interval_type, method) - half_width
+        return _precision(std, size, conf_level, interval_type, dist) - precision
 
-    size = ceil(brentq(func, 1.1, SAMPLE_SIZE_SEARCH_MAX))
-    return size
+    return ceil(brentq(func, 1 + 1e-12, 1e12))
 
 
 def solve_std(
     *,
-    half_width: float,
+    precision: float,
     size: int,
     conf_level: float = 0.95,
-    interval_type: Literal["one-sided", "two-sided"] = "two-sided",
-    method: Literal["z", "t"] = "t",
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"] = "two-sided",
+    dist: Literal["z", "t"] = "t",
 ) -> float:
     """
-    Calculate the required standard deviation for the half-width of one mean confidence interval.
+    Estimate the required standard deviation, given the distance from the single-group mean to the confidence limit (commonly known as precision).
 
     Args:
-        half_width (float):
-            Half-width of the confidence interval ($d$).
-        size (int):
-            Sample size ($n$).
-        conf_level (float, Optional):
+        precision:
+            Distance from the single-group mean to the confidence limit.
+        size:
+            Sample size.
+        conf_level:
             Confidence level.
-        interval_type (Literal["one-sided", "two-sided"], optional):
+
+            - If `interval_type` is `'two-sided'`, a two-sided confidence level should be specified
+            - If `interval_type` is `'one-sided'`, `'lower'` or `'upper'`, a one-sided confidence level should be specified
+        interval_type:
             The type of confidence interval.
-        method (Literal["z", "t"], optional):
+
+            - `'two-sided'`: Two-sided confidence interval $(L, U)$.
+            - `'one-sided'`: One-sided confidence interval $(L, +\infty)$ or $(-\infty, U)$.
+            - `'lower'`: Lower one-sided confidence interval $(L, +\infty)$.
+            - `'upper'`: Upper one-sided confidence interval $(-\infty, U)$.
+        dist:
             The distribution used to construct the confidence interval.
 
+            - `'z'`: Normal distribution.
+            - `'t'`: Student's t-distribution.
+
     Returns:
-        (float): The required standard deviation.
+        float: The required standard deviation.
+
+    Notes:
+        Since the confidence interval for the single-group mean is symmetric, specifying `interval_type` as `'lower'`, `'upper'`, or `'one-sided'` works consistently.
     """
 
-    multiplier = _ci_half_width(1, size, conf_level, interval_type, method)
-    std = half_width / multiplier
-
-    return float(std)
+    # First calculate precision d' under standard deviation s' = 1, and then use the conversion formula s = d/d' to
+    # directly obtain the required standard deviation s under given precision d.
+    # This algorithm does not require the use of brentq inverse solution.
+    return precision / _precision(1, size, conf_level, interval_type, dist)

--- a/src/pystatpower/mean/single/ci.py
+++ b/src/pystatpower/mean/single/ci.py
@@ -42,7 +42,7 @@ def _precision_t(
     match interval_type:
         case "two-sided":
             precision = t.ppf(1 - alpha / 2, df) * se
-        case "one-sided":
+        case "one-sided" | "lower" | "upper":
             precision = t.ppf(1 - alpha, df) * se
 
     return float(precision)
@@ -88,10 +88,10 @@ def solve_precision(
         interval_type:
             The type of confidence interval.
 
-            - `'two-sided'`: Two-sided confidence interval $(L, U)$.
-            - `'one-sided'`: One-sided confidence interval $(L, +\infty)$ or $(-\infty, U)$.
-            - `'lower'`: Lower one-sided confidence interval $(L, +\infty)$.
-            - `'upper'`: Upper one-sided confidence interval $(-\infty, U)$.
+            - `'two-sided'`: Two-sided confidence interval.
+            - `'one-sided'`: One-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         dist:
             The distribution used to construct the confidence interval.
 
@@ -132,10 +132,10 @@ def solve_size(
         interval_type:
             The type of confidence interval.
 
-            - `'two-sided'`: Two-sided confidence interval $(L, U)$.
-            - `'one-sided'`: One-sided confidence interval $(L, +\infty)$ or $(-\infty, U)$.
-            - `'lower'`: Lower one-sided confidence interval $(L, +\infty)$.
-            - `'upper'`: Upper one-sided confidence interval $(-\infty, U)$.
+            - `'two-sided'`: Two-sided confidence interval.
+            - `'one-sided'`: One-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         dist:
             The distribution used to construct the confidence interval.
 
@@ -179,10 +179,10 @@ def solve_std(
         interval_type:
             The type of confidence interval.
 
-            - `'two-sided'`: Two-sided confidence interval $(L, U)$.
-            - `'one-sided'`: One-sided confidence interval $(L, +\infty)$ or $(-\infty, U)$.
-            - `'lower'`: Lower one-sided confidence interval $(L, +\infty)$.
-            - `'upper'`: Upper one-sided confidence interval $(-\infty, U)$.
+            - `'two-sided'`: Two-sided confidence interval.
+            - `'one-sided'`: One-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
         dist:
             The distribution used to construct the confidence interval.
 

--- a/tests/test_mean/test_single/test_ci.py
+++ b/tests/test_mean/test_single/test_ci.py
@@ -129,3 +129,23 @@ def test_std(case: TestCase) -> None:
         )
         == case.std
     )
+
+
+def test_interval_type_lower_upper(case: TestCase) -> None:
+    assert (
+        round(solve_precision(std=case.std, size=case.size, conf_level=case.conf_level, interval_type="one-sided", dist=case.dist), 9)
+        == round(solve_precision(std=case.std, size=case.size, conf_level=case.conf_level, interval_type="lower", dist=case.dist), 9)
+        == round(solve_precision(std=case.std, size=case.size, conf_level=case.conf_level, interval_type="upper", dist=case.dist), 9)
+    )
+
+    assert (
+        solve_size(precision=case.actual_precision, std=case.std, conf_level=case.conf_level, interval_type="one-sided", dist=case.dist)
+        == solve_size(precision=case.actual_precision, std=case.std, conf_level=case.conf_level, interval_type="lower", dist=case.dist)
+        == solve_size(precision=case.actual_precision, std=case.std, conf_level=case.conf_level, interval_type="upper", dist=case.dist)
+    )
+
+    assert (
+        round(solve_std(precision=case.actual_precision, size=case.size, conf_level=case.conf_level, interval_type="one-sided", dist=case.dist), 9)
+        == round(solve_std(precision=case.actual_precision, size=case.size, conf_level=case.conf_level, interval_type="lower", dist=case.dist), 9)
+        == round(solve_std(precision=case.actual_precision, size=case.size, conf_level=case.conf_level, interval_type="upper", dist=case.dist), 9)
+    )

--- a/tests/test_mean/test_single/test_ci.py
+++ b/tests/test_mean/test_single/test_ci.py
@@ -4,108 +4,127 @@
 from dataclasses import dataclass
 from typing import Literal
 
-from pystatpower.mean.single.ci import solve_half_width, solve_size, solve_std
+from pystatpower.mean.single.ci import solve_precision, solve_size, solve_std
 
 from tests.models import BaseTestCase
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TestCase(BaseTestCase):
-    target_half_width: float
-    actual_half_width: float
     std: float
     size: int
     conf_level: float
-    interval_type: Literal["one-sided", "two-sided"]
-    method: Literal["z", "t"]
+    interval_type: Literal["two-sided", "one-sided", "lower", "upper"]
+    dist: Literal["z", "t"]
+    precision: float
+    actual_precision: float
 
 
-case_group = (
-    [
-        # Regular Test Cases: half_width = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "one-sided", method = "z"
-        TestCase(target_half_width=target_half_width, actual_half_width=actual_half_width, std=10, size=size, conf_level=0.95, interval_type="one-sided", method="z")
-        for target_half_width, actual_half_width, size in [
-            (1, 0.9992, 271),
-            (2, 1.9947, 68),
-            (3, 2.9542, 31),
-            (4, 3.9894, 17),
-            (5, 4.9594, 11),
-            (6, 5.8154, 8),
-            (7, 6.7151, 6),
-            (8, 7.356, 5),
-            (9, 8.2243, 4),
-            (10, 9.4966, 3),
-        ]
+case_group_z = [
+    # precision = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "one-sided", dist = "z"
+    TestCase(precision=precision, actual_precision=actual_precision, std=10, size=size, conf_level=0.95, interval_type="one-sided", dist="z")
+    for precision, actual_precision, size in [
+        (1, 0.9992, 271),
+        (2, 1.9947, 68),
+        (3, 2.9542, 31),
+        (4, 3.9894, 17),
+        (5, 4.9594, 11),
+        (6, 5.8154, 8),
+        (7, 6.7151, 6),
+        (8, 7.356, 5),
+        (9, 8.2243, 4),
+        (10, 9.4966, 3),
     ]
-    + [
-        # Regular Test Cases: half_width = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "two-sided", method = "z"
-        TestCase(target_half_width=target_half_width, actual_half_width=actual_half_width, std=10, size=size, conf_level=0.95, interval_type="two-sided", method="z")
-        for target_half_width, actual_half_width, size in [
-            (1, 0.9989, 385),
-            (2, 1.99, 97),
-            (3, 2.9889, 43),
-            (4, 3.9199, 25),
-            (5, 4.8999, 16),
-            (6, 5.9095, 11),
-            (7, 6.9295, 8),
-            (8, 7.408, 7),
-            (9, 8.7652, 5),
-            (10, 9.7998, 4),
-        ]
+] + [
+    # precision = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "two-sided", dist = "z"
+    TestCase(precision=precision, actual_precision=actual_precision, std=10, size=size, conf_level=0.95, interval_type="two-sided", dist="z")
+    for precision, actual_precision, size in [
+        (1, 0.9989, 385),
+        (2, 1.99, 97),
+        (3, 2.9889, 43),
+        (4, 3.9199, 25),
+        (5, 4.8999, 16),
+        (6, 5.9095, 11),
+        (7, 6.9295, 8),
+        (8, 7.408, 7),
+        (9, 8.7652, 5),
+        (10, 9.7998, 4),
     ]
-    + [
-        # Regular Test Cases: half_width = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "one-sided", method = "t"
-        TestCase(target_half_width=target_half_width, actual_half_width=actual_half_width, std=10, size=size, conf_level=0.95, interval_type="one-sided", method="t")
-        for target_half_width, actual_half_width, size in [
-            (1, 0.9989, 273),
-            (2, 1.9927, 70),
-            (3, 2.9973, 32),
-            (4, 3.9782, 19),
-            (5, 4.9432, 13),
-            (6, 5.7968, 10),
-            (7, 6.6983, 8),
-            (8, 7.3445, 7),
-            (9, 8.2264, 6),
-            (10, 9.5339, 5),
-        ]
+]
+case_group_t = [
+    # precision = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "one-sided", dist = "t"
+    TestCase(precision=precision, actual_precision=actual_precision, std=10, size=size, conf_level=0.95, interval_type="one-sided", dist="t")
+    for precision, actual_precision, size in [
+        (1, 0.9989, 273),
+        (2, 1.9927, 70),
+        (3, 2.9973, 32),
+        (4, 3.9782, 19),
+        (5, 4.9432, 13),
+        (6, 5.7968, 10),
+        (7, 6.6983, 8),
+        (8, 7.3445, 7),
+        (9, 8.2264, 6),
+        (10, 9.5339, 5),
     ]
-    + [
-        # Regular Test Cases: half_width = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "two-sided", method = "t"
-        TestCase(target_half_width=target_half_width, actual_half_width=actual_half_width, std=10, size=size, conf_level=0.95, interval_type="two-sided", method="t")
-        for target_half_width, actual_half_width, size in [
-            (1, 0.9994, 387),
-            (2, 1.9945, 99),
-            (3, 2.9696, 46),
-            (4, 3.9559, 27),
-            (5, 4.9729, 18),
-            (6, 5.7738, 14),
-            (7, 6.7181, 11),
-            (8, 7.6867, 9),
-            (9, 8.3602, 8),
-            (10, 9.2485, 7),
-        ]
+] + [
+    # precision = 1 to 10 by 1, std = 10, conf_level = 0.95, interval_type = "two-sided", dist = "t"
+    TestCase(precision=precision, actual_precision=actual_precision, std=10, size=size, conf_level=0.95, interval_type="two-sided", dist="t")
+    for precision, actual_precision, size in [
+        (1, 0.9994, 387),
+        (2, 1.9945, 99),
+        (3, 2.9696, 46),
+        (4, 3.9559, 27),
+        (5, 4.9729, 18),
+        (6, 5.7738, 14),
+        (7, 6.7181, 11),
+        (8, 7.6867, 9),
+        (9, 8.3602, 8),
+        (10, 9.2485, 7),
     ]
-)
+]
+
+case_group = case_group_z + case_group_t
 
 
-def test_solve_half_width(case: TestCase) -> None:
+def test_solve_precision(case: TestCase) -> None:
     assert (
         round(
-            solve_half_width(std=case.std, size=case.size, conf_level=case.conf_level, interval_type=case.interval_type, method=case.method),
+            solve_precision(
+                std=case.std,
+                size=case.size,
+                conf_level=case.conf_level,
+                interval_type=case.interval_type,
+                dist=case.dist,
+            ),
             4,
         )
-        == case.actual_half_width
+        == case.actual_precision
     )
 
 
 def test_solve_size(case: TestCase) -> None:
-    assert solve_size(half_width=case.target_half_width, std=case.std, conf_level=case.conf_level, interval_type=case.interval_type, method=case.method) == case.size
+    assert (
+        solve_size(
+            precision=case.precision,
+            std=case.std,
+            conf_level=case.conf_level,
+            interval_type=case.interval_type,
+            dist=case.dist,
+        )
+        == case.size
+    )
 
 
 def test_std(case: TestCase) -> None:
     assert (
         round(
-            solve_std(half_width=case.actual_half_width, size=case.size, conf_level=case.conf_level, interval_type=case.interval_type, method=case.method),
+            solve_std(
+                precision=case.actual_precision,
+                size=case.size,
+                conf_level=case.conf_level,
+                interval_type=case.interval_type,
+                dist=case.dist,
+            ),
             0,
         )
         == case.std


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Rename functions and parameters for clarity

- Update interval_type literals (add "lower", "upper")

- Improve docstrings with detailed parameter notes

- Optimize solve_std to avoid root-finding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old_half_width["_ci_half_width"] -- "renamed to" --> new_precision["_precision"]
  old_solve_half_width["solve_half_width"] -- "renamed to" --> new_solve_precision["solve_precision"]
  old_param_hw["half_width"] -- "renamed to" --> new_param_prec["precision"]
  old_param_method["method"] -- "renamed to" --> new_param_dist["dist"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.py</strong><dd><code>Rename functions and parameters, enhance docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/mean/single/ci.py

<ul><li>Renamed internal functions from <code>_ci_half_width_*</code> to <code>_precision_*</code><br> <li> Renamed public function <code>solve_half_width</code> to <code>solve_precision</code><br> <li> Renamed parameter <code>half_width</code> to <code>precision</code> in <code>solve_size</code> and <code>solve_std</code><br> <li> Renamed parameter <code>method</code> to <code>dist</code> in all functions<br> <li> Extended <code>interval_type</code> literal to include <code>'lower'</code> and <code>'upper'</code><br> <li> Improved docstrings with detailed parameter descriptions and notes<br> <li> Removed import of <code>SAMPLE_SIZE_SEARCH_MAX</code> and changed <code>solve_size</code> search <br>bound<br> <li> Simplified <code>solve_std</code> to use direct computation instead of root-finding</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/459/files#diff-01a0473ad32e55116ccfce70a2f4446a340f2bedb8f943b450b1937627a34874">+121/-70</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ci.py</strong><dd><code>Update tests to match renamed functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_mean/test_single/test_ci.py

<ul><li>Updated imports to use <code>solve_precision</code> instead of <code>solve_half_width</code><br> <li> Changed <code>TestCase</code> fields: <code>target_half_width</code> -> <code>precision</code>, <br><code>actual_half_width</code> -> <code>actual_precision</code>, <code>method</code> -> <code>dist</code><br> <li> Split test cases into <code>case_group_z</code> and <code>case_group_t</code> for better <br>organization<br> <li> Adapted test functions to use new parameter names and field names</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/459/files#diff-fc23b65a4de1479ad7823ffd3effe1e4cef5364837dba83eb1e518dbda31e3c1">+92/-73</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

