### PR TITLE
refactor(proportion.single.ci): optimize the algorithm and docstring

### DIFF
--- a/src/pystatpower/proportion/single/ci.py
+++ b/src/pystatpower/proportion/single/ci.py
@@ -4,7 +4,7 @@ from typing import Literal
 from scipy.optimize import OptimizeResult, brentq, minimize_scalar
 from scipy.stats import f, norm
 
-from ..._constant import SAMPLE_SIZE_SEARCH_MAX
+from ..._math_utils import _domain_square_root_of_quad
 
 
 def _distance_wald(
@@ -13,19 +13,32 @@ def _distance_wald(
     conf_level: float,
     interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
-    """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wald method."""
+    """
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval),
+    using the Wald method.
+    """
+
+    alpha = 1 - conf_level
+
+    se = sqrt(proportion * (1 - proportion) / size)
 
     match interval_type:
         case "two-sided":
-            lower_limit = proportion - norm.ppf((1 + conf_level) / 2) * sqrt(proportion * (1 - proportion) / size)
-            upper_limit = proportion + norm.ppf((1 + conf_level) / 2) * sqrt(proportion * (1 - proportion) / size)
-            distance = min(upper_limit, 1) - max(lower_limit, 0)
+            z = norm.ppf(1 - alpha / 2)
+            L = proportion - z * se
+            U = proportion + z * se
+            distance = min(U, 1) - max(L, 0)
         case "lower":
-            lower_limit = proportion - norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size)
-            distance = proportion - max(lower_limit, 0)
+            z = norm.ppf(1 - alpha)
+            L = proportion - z * se
+            # U = 1
+            distance = proportion - max(L, 0)
         case "upper":
-            upper_limit = proportion + norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size)
-            distance = min(upper_limit, 1) - proportion
+            z = norm.ppf(1 - alpha)
+            # L = 0
+            U = proportion + z * se
+            distance = min(U, 1) - proportion
 
     return float(distance)
 
@@ -36,31 +49,33 @@ def _distance_wald_cc(
     conf_level: float,
     interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
-    """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wald method with continuity correction."""
+    """
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval),
+    using the Wald method with continuity correction.
+    """
+
+    alpha = 1 - conf_level
+
+    se = sqrt(proportion * (1 - proportion) / size)
+    c = 1 / (2 * size)
 
     match interval_type:
         case "two-sided":
-            lower_limit = (
-                proportion
-                - norm.ppf((1 + conf_level) / 2) * sqrt(proportion * (1 - proportion) / size)
-                - 1 / (2 * size)
-            )
-            upper_limit = (
-                proportion
-                + norm.ppf((1 + conf_level) / 2) * sqrt(proportion * (1 - proportion) / size)
-                + 1 / (2 * size)
-            )
-            distance = min(upper_limit, 1) - max(lower_limit, 0)
+            z = norm.ppf(1 - alpha / 2)
+            L = proportion - z * se - c
+            U = proportion + z * se + c
+            distance = min(U, 1) - max(L, 0)
         case "lower":
-            lower_limit = (
-                proportion - norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size) - 1 / (2 * size)
-            )
-            distance = proportion - max(lower_limit, 0)
+            z = norm.ppf(1 - alpha)
+            L = proportion - z * se - c
+            # U = 1
+            distance = proportion - max(L, 0)
         case "upper":
-            upper_limit = (
-                proportion + norm.ppf(conf_level) * sqrt(proportion * (1 - proportion) / size) + 1 / (2 * size)
-            )
-            distance = min(upper_limit, 1) - proportion
+            z = norm.ppf(1 - alpha)
+            # L = 0
+            U = proportion + z * se + c
+            distance = min(U, 1) - proportion
 
     return float(distance)
 
@@ -71,33 +86,42 @@ def _distance_wilson(
     conf_level: float,
     interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
-    """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wilson method."""
+    """
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval),
+    using the Wilson method.
+    """
+
+    alpha = 1 - conf_level
 
     match interval_type:
         case "two-sided":
-            lower_limit = (
-                (2 * size * proportion + norm.ppf((1 + conf_level) / 2) ** 2)
-                - norm.ppf((1 + conf_level) / 2)
-                * sqrt(norm.ppf((1 + conf_level) / 2) ** 2 + 4 * size * proportion * (1 - proportion))
-            ) / (2 * (size + norm.ppf((1 + conf_level) / 2) ** 2))
-            upper_limit = (
-                (2 * size * proportion + norm.ppf((1 + conf_level) / 2) ** 2)
-                + norm.ppf((1 + conf_level) / 2)
-                * sqrt(norm.ppf((1 + conf_level) / 2) ** 2 + 4 * size * proportion * (1 - proportion))
-            ) / (2 * (size + norm.ppf((1 + conf_level) / 2) ** 2))
-            distance = upper_limit - lower_limit
+            z = norm.ppf(1 - alpha / 2)
+            a = 2 * (size + z**2)
+            b = 2 * size * proportion + z**2
+            c = z**2 + 4 * size * proportion * (1 - proportion)
+
+            L = (b - z * sqrt(c)) / a
+            U = (b + z * sqrt(c)) / a
+            distance = U - L
         case "lower":
-            lower_limit = (
-                (2 * size * proportion + norm.ppf(conf_level) ** 2)
-                - norm.ppf(conf_level) * sqrt(norm.ppf(conf_level) ** 2 + 4 * size * proportion * (1 - proportion))
-            ) / (2 * (size + norm.ppf(conf_level) ** 2))
-            distance = proportion - lower_limit
+            z = norm.ppf(1 - alpha)
+            a = 2 * (size + z**2)
+            b = 2 * size * proportion + z**2
+            c = z**2 + 4 * size * proportion * (1 - proportion)
+
+            L = (b - z * sqrt(c)) / a
+            # U = 1
+            distance = proportion - L
         case "upper":
-            upper_limit = (
-                (2 * size * proportion + norm.ppf(conf_level) ** 2)
-                + norm.ppf(conf_level) * sqrt(norm.ppf(conf_level) ** 2 + 4 * size * proportion * (1 - proportion))
-            ) / (2 * (size + norm.ppf(conf_level) ** 2))
-            distance = upper_limit - proportion
+            z = norm.ppf(1 - alpha)
+            a = 2 * (size + z**2)
+            b = 2 * size * proportion + z**2
+            c = z**2 + 4 * size * proportion * (1 - proportion)
+
+            # L = 0
+            U = (b + z * sqrt(c)) / a
+            distance = U - proportion
 
     return float(distance)
 
@@ -108,52 +132,45 @@ def _distance_wilson_cc(
     conf_level: float,
     interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
-    """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Wilson method, with continuity correction."""
+    """
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval),
+    using the Wilson method with continuity correction.
+    """
+
+    alpha = 1 - conf_level
 
     match interval_type:
         case "two-sided":
-            lower_limit = (
-                (2 * size * proportion + norm.ppf((1 + conf_level) / 2) ** 2 - 1)
-                - norm.ppf((1 + conf_level) / 2)
-                * sqrt(
-                    norm.ppf((1 + conf_level) / 2) ** 2
-                    - 1 / size
-                    + 4 * size * proportion * (1 - proportion)
-                    + 4 * proportion
-                    - 2
-                )
-            ) / (2 * (size + norm.ppf((1 + conf_level) / 2) ** 2))
+            z = norm.ppf(1 - alpha / 2)
+            a = 2 * (size + z**2)
+            b = 2 * size * proportion + z**2
+            c1 = z**2 - 1 / size + 4 * size * proportion * (1 - proportion)
+            c2 = 4 * proportion - 2
 
-            upper_limit = (
-                (2 * size * proportion + norm.ppf((1 + conf_level) / 2) ** 2 + 1)
-                + norm.ppf((1 + conf_level) / 2)
-                * sqrt(
-                    norm.ppf((1 + conf_level) / 2) ** 2
-                    - 1 / size
-                    + 4 * size * proportion * (1 - proportion)
-                    - 4 * proportion
-                    + 2
-                )
-            ) / (2 * (size + norm.ppf((1 + conf_level) / 2) ** 2))
-            distance = upper_limit - lower_limit
+            L = ((b - 1) - z * sqrt(c1 + c2)) / a
+            U = ((b + 1) + z * sqrt(c1 - c2)) / a
+            distance = U - L
         case "lower":
-            lower_limit = (
-                (2 * size * proportion + norm.ppf(conf_level) ** 2 - 1)
-                - norm.ppf(conf_level)
-                * sqrt(
-                    norm.ppf(conf_level) ** 2 - 1 / size + 4 * size * proportion * (1 - proportion) + 4 * proportion - 2
-                )
-            ) / (2 * (size + norm.ppf(conf_level) ** 2))
-            distance = proportion - lower_limit
+            z = norm.ppf(1 - alpha)
+            a = 2 * (size + z**2)
+            b = 2 * size * proportion + z**2
+            c1 = z**2 - 1 / size + 4 * size * proportion * (1 - proportion)
+            c2 = 4 * proportion - 2
+
+            L = ((b - 1) - z * sqrt(c1 + c2)) / a
+            # U = 1
+            distance = proportion - L
         case "upper":
-            upper_limit = (
-                (2 * size * proportion + norm.ppf(conf_level) ** 2 + 1)
-                + norm.ppf(conf_level)
-                * sqrt(
-                    norm.ppf(conf_level) ** 2 - 1 / size + 4 * size * proportion * (1 - proportion) - 4 * proportion + 2
-                )
-            ) / (2 * (size + norm.ppf(conf_level) ** 2))
-            distance = upper_limit - proportion
+            z = norm.ppf(1 - alpha)
+            a = 2 * (size + z**2)
+            b = 2 * size * proportion + z**2
+            c1 = z**2 - 1 / size + 4 * size * proportion * (1 - proportion)
+            c2 = 4 * proportion - 2
+
+            # L = 0
+            U = ((b + 1) + z * sqrt(c1 - c2)) / a
+            distance = U - proportion
 
     return float(distance)
 
@@ -164,47 +181,31 @@ def _distance_clopper_pearson(
     conf_level: float,
     interval_type: Literal["two-sided", "lower", "upper"],
 ) -> float:
-    """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound using the Clopper-Pearson method."""
+    """
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval),
+    using the Clopper-Pearson method.
+    """
+
+    alpha = 1 - conf_level
+
+    n = size
+    p = proportion
+    q = 1 - p
 
     match interval_type:
         case "two-sided":
-            lower_limit = 1 / (
-                1
-                + (size * (1 - proportion) + 1)
-                / (
-                    size
-                    * proportion
-                    * f.ppf((1 - conf_level) / 2, 2 * size * proportion, 2 * (size * (1 - proportion) + 1))
-                )
-            )
-            upper_limit = 1 / (
-                1
-                + size
-                * (1 - proportion)
-                / (
-                    (size * proportion + 1)
-                    * f.ppf((1 + conf_level) / 2, 2 * (size * proportion + 1), 2 * size * (1 - proportion))
-                )
-            )
-            distance = upper_limit - lower_limit
+            L = 1 / (1 + (n * q + 1) / (n * p * f.ppf(alpha / 2, 2 * n * p, 2 * (n * q + 1))))
+            U = 1 / (1 + n * q / ((n * p + 1) * f.ppf(1 - alpha / 2, 2 * (n * p + 1), 2 * n * q)))
+            distance = U - L
         case "lower":
-            lower_limit = 1 / (
-                1
-                + (size * (1 - proportion) + 1)
-                / (size * proportion * f.ppf(1 - conf_level, 2 * size * proportion, 2 * (size * (1 - proportion) + 1)))
-            )
-            distance = proportion - lower_limit
+            L = 1 / (1 + (n * q + 1) / (n * p * f.ppf(alpha, 2 * n * p, 2 * (n * q + 1))))
+            # U = 1
+            distance = proportion - L
         case "upper":
-            upper_limit = 1 / (
-                1
-                + size
-                * (1 - proportion)
-                / (
-                    (size * proportion + 1)
-                    * f.ppf(conf_level, 2 * (size * proportion + 1), 2 * size * (1 - proportion))
-                )
-            )
-            distance = upper_limit - proportion
+            # L = 0
+            U = 1 / (1 + n * q / ((n * p + 1) * f.ppf(1 - alpha, 2 * (n * p + 1), 2 * n * q)))
+            distance = U - proportion
 
     return float(distance)
 
@@ -214,13 +215,16 @@ def _distance(
     size: float,
     conf_level: float,
     interval_type: Literal["two-sided", "lower", "upper"],
-    method: Literal["clopper-pearson", "wald", "wilson"],
+    method: Literal["wald", "wilson", "clopper-pearson", "cp"],
     continuity_correction: bool = False,
 ) -> float:
-    """Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound."""
+    """
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval).
+    """
 
     match method:
-        case "clopper-pearson":
+        case "clopper-pearson" | "cp":
             return _distance_clopper_pearson(proportion, size, conf_level, interval_type)
         case "wald":
             if continuity_correction:
@@ -240,35 +244,40 @@ def solve_distance(
     size: int,
     conf_level: float = 0.95,
     interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
-    method: Literal["clopper-pearson", "wald", "wilson"] = "clopper-pearson",
+    method: Literal["wald", "wilson", "clopper-pearson", "cp"] = "cp",
     continuity_correction: bool = False,
 ) -> float:
     """
-    Calculate the confidence interval width for one proportion or the distance from the proportion to the confidence bound.
+    Calculate the width of the confidence interval for a single-group proportion (two-sided confidence interval),
+    or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval).
 
     Args:
-        proportion (float):
+        proportion:
             Proportion.
-        size (int):
+        size:
             Sample size.
-        conf_level (float, optional):
+        conf_level:
             Confidence level.
-        interval_type (Literal["two-sided", "lower", "upper"], optional):
+
+            - If `interval_type` is `'two-sided'`, a two-sided confidence level is required.
+            - If `interval_type` is `'lower'` or `'upper'`, a one-sided confidence level is required.
+        interval_type:
             Type of the confidence interval.
 
-            - `two-sided`: Two-sided confidence interval $(L, U)$.
-            - `lower`: Lower one-sided confidence interval $(L, +\\infty)$.
-            - `upper`: Upper one-sided confidence interval $(-\\infty, U)$.
-        method (Literal["clopper-pearson", "wald", "wilson"], optional):
-            Method used in calculation of the confidence interval.
-        continuity_correction (bool, optional):
-            Whether or not to apply Yate's continuity correction, only valid for `method='wald'` or `method='wilson'`.
+            - `'two-sided'`: Two-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
+        method:
+            The method used to construct the confidence interval.
+
+            - `'wald'`: Wald method.
+            - `'wilson'`: Wilson method.
+            - `'clopper-pearson'`, `'cp'`: Clopper-Pearson method.
+        continuity_correction:
+            Whether to apply the continuity correction, only takes effect when `method` is specified as `'wald'` or `'wilson'`
 
     Returns:
-        (float): The confidence interval width.
-
-    Raises:
-        ValueError: If `method='wald'` or `method='wilson'`, and `continuity_correction=None`.
+        float: The confidence interval width (two-sided confidence interval), or the distance from the proportion to the confidence limit (lower or upper one-sided confidence interval).
     """
 
     return _distance(proportion, size, conf_level, interval_type, method, continuity_correction)
@@ -280,82 +289,93 @@ def solve_size(
     distance: float,
     conf_level: float = 0.95,
     interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
-    method: Literal["clopper-pearson", "wald", "wilson"] = "clopper-pearson",
+    method: Literal["wald", "wilson", "clopper-pearson", "cp"] = "cp",
     continuity_correction: bool = False,
 ) -> int:
     """
-    Estimate the required sample size, given either a desired confidence interval width or a desired distance from the proportion to the confidence bound.
+    Estimate the required sample size for a single-group proportion confidence interval.
+
+    For two-sided confidence interval, the confidence interval width needs to be given.
+
+    For one-sided confidence interval, the distance from the proportion to the confidence limit needs to be given.
 
     Args:
-        proportion (float):
+        proportion:
             Proportion.
-        distance (float):
-            - if `interval_type` = `'two-sided'`, provide confidence interval width.
-            - if `interval_type` = `'lower'` or `interval_type` = `'upper'`, provide the distance from the proportion to the confidence bound.
-        conf_level (float, optional):
+        distance:
+            - If `interval_type` is `'two-sided'`, a confidence interval width is required.
+            - If `interval_type` is `'lower'` or `'upper'`, a distance from the proportion to the confidence limit is required.
+        conf_level:
             Confidence level.
-        interval_type (Literal["two-sided", "lower", "upper"], optional):
+
+            - If `interval_type` is `'two-sided'`, a two-sided confidence level is required.
+            - If `interval_type` is `'lower'` or `'upper'`, a one-sided confidence level is required.
+        interval_type:
             Type of the confidence interval.
 
-            - `two-sided`: Two-sided confidence interval $(L, U)$.
-            - `lower`: Lower one-sided confidence interval $(L, +\\infty)$.
-            - `upper`: Upper one-sided confidence interval $(-\\infty, U)$.
-        method (Literal["clopper-pearson", "wald", "wilson"], optional):
-            Method used in calculation of the confidence interval.
-        continuity_correction (bool | None, optional):
-            Whether or not to apply Yate's continuity correction, only valid for `method='wald'` or `method='wilson'`.
+            - `'two-sided'`: Two-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
+        method:
+            The method used to construct the confidence interval.
+
+            - `'wald'`: Wald method.
+            - `'wilson'`: Wilson method.
+            - `'clopper-pearson'`, `'cp'`: Clopper-Pearson method.
+        continuity_correction:
+            Whether to apply the continuity correction, only takes effect when `method` is specified as `'wald'` or `'wilson'`
 
     Returns:
-        (int): The required sample size.
-
-    Raises:
-        ValueError: If `method='wald'` or `method='wilson'`, and `continuity_correction=None`.
+        int: The required sample size.
     """
 
     def func(size: float) -> float:
         return _distance(proportion, size, conf_level, interval_type, method, continuity_correction) - distance
 
     if method == "wilson" and continuity_correction:
-        # wilson score 连续性校正公式中的分子可能存在对负数开算术平方根的情况，这可能会导致置信区间宽度计算失败，因此需要先求出根号下的定义域，缩小 brentq 搜索范围
-
-        z = norm.ppf((1 + conf_level) / 2) if interval_type == "two-sided" else norm.ppf(conf_level)
-
-        a = 4 * proportion * (1 - proportion)
-        b1 = z**2 + 4 * proportion - 2
-        b2 = z**2 - 4 * proportion + 2
-        c = -1
-
-        # 对 Lower Limit 求根号下的定义域
-        n1 = (-b1 - sqrt(b1**2 - 4 * a * c)) / (2 * a)
-        n2 = (-b1 + sqrt(b1**2 - 4 * a * c)) / (2 * a)
-
-        # 对 Upper Limit 求根号下的定义域
-        n3 = (-b2 - sqrt(b2**2 - 4 * a * c)) / (2 * a)
-        n4 = (-b2 + sqrt(b2**2 - 4 * a * c)) / (2 * a)
-
+        # The numerator in the wilson score continuity correction formula may take the arithmetic square root of a
+        # negative number,which may cause the confidence interval width calculation to fail. Therefore, it is necessary
+        # to first find the domain under the root sign and narrow the brentq search range.
+        alpha = 1 - conf_level
         match interval_type:
             case "two-sided":
-                lower_bound = max(n1, n2, n3, n4)
+                z = norm.ppf(1 - alpha / 2)
+
+                a = 4 * proportion * (1 - proportion)
+                b1 = z**2 + (4 * proportion - 2)
+                b2 = z**2 - (4 * proportion - 2)
+                c = -1
+                lb = max(_domain_square_root_of_quad(a, b1, c)[1][0], _domain_square_root_of_quad(a, b2, c)[1][0])
             case "lower":
-                lower_bound = max(n3, n4)
+                z = norm.ppf(1 - alpha)
+
+                a = 4 * proportion * (1 - proportion)
+                b = z**2 + (4 * proportion - 2)
+                c = -1
+                lb = _domain_square_root_of_quad(a, b, c)[1][0]
             case "upper":
-                lower_bound = max(n1, n2)
+                z = norm.ppf(1 - alpha)
 
-        upper_bound = SAMPLE_SIZE_SEARCH_MAX
+                a = 4 * proportion * (1 - proportion)
+                b = z**2 - (4 * proportion - 2)
+                c = -1
+                lb = _domain_square_root_of_quad(a, b, c)[1][0]
 
-        # wilson score 连续性校正计算出的置信区间宽度并随样本量增大而单调减小，而是在小样本区间内先增大，随着样本量继续增大，置信区间宽度逐渐减小。
-        # 因此，直接使用 brentq 可能无法收敛，必须先找到置信区间的极大值点 $n'$，然后将 brentq 的搜索区间限定为 $[n', [SAMPLE_SIZE_SEARCH_MAX]]$，才能保证收敛。
-        res: OptimizeResult = minimize_scalar(lambda size: -func(size), bounds=(lower_bound, upper_bound))
+        ub = 1e12
+
+        # The width of the confidence interval calculated by wilson score continuity correction does not decreases
+        # monotonically as the sample size increases. Instead, it first increases in the small sample range, and as
+        # the sample size continues to increase, the width of the confidence interval gradually decreases. Therefore,
+        # using brentq directly may not converge. You must first find the maximum value point $n'$ of the confidence
+        # interval, and then limit the search interval of brentq to $(n', 1e12)$ to ensure convergence.
+        res: OptimizeResult = minimize_scalar(lambda size: -func(size), bounds=(lb, ub))
         if -res.fun < 0:
-            raise ValueError("No solution found.")
+            return 2  # Any sample size can meet the requirements, and the minimum allowed sample size 2 is directly returned.
         else:
-            lower_bound = max(lower_bound, res.x)
-
-        size = brentq(func, lower_bound, upper_bound)
+            lb = max(lb, res.x)
+            return ceil(brentq(func, lb, ub))
     else:
-        size = brentq(func, 0.000001, SAMPLE_SIZE_SEARCH_MAX)
-
-    return ceil(size)
+        return ceil(brentq(func, 1e-12, 1e12))
 
 
 def solve_proportion(
@@ -364,47 +384,60 @@ def solve_proportion(
     distance: float,
     conf_level: float = 0.95,
     interval_type: Literal["two-sided", "lower", "upper"] = "two-sided",
-    method: Literal["clopper-pearson", "wald", "wilson"] = "clopper-pearson",
+    method: Literal["wald", "wilson", "clopper-pearson", "cp"] = "cp",
     continuity_correction: bool = False,
-    search_direction: Literal["below", "above"] = "above",
+    direction: Literal["greater", "less"] = "greater",
 ) -> float:
-    """Estimate the required proportion, given either a desired confidence interval width or a desired distance from the proportion to the confidence bound.
+    """
+    Estimate the required proportion for a single-group proportion confidence interval.
+
+    For two-sided confidence interval, the confidence interval width needs to be given.
+
+    For one-sided confidence interval, the distance from the proportion to the confidence limit needs to be given.
 
     Args:
-        size (int):
+        size:
             Sample size.
-        distance (float):
-            - if `interval_type` = `'two-sided'`, provide confidence interval width.
-            - if `interval_type` = `'lower'` or `interval_type` = `'upper'`, provide the distance from the proportion to the confidence bound.
-        conf_level (float, optional):
+        distance:
+            - If `interval_type` is `'two-sided'`, a confidence interval width is required.
+            - If `interval_type` is `'lower'` or `'upper'`, a distance from the proportion to the confidence limit is required.
+        conf_level:
             Confidence level.
-        interval_type (Literal["two-sided", "lower", "upper"], optional):
+
+            - If `interval_type` is `'two-sided'`, a two-sided confidence level should is required.
+            - If `interval_type` is `'lower'` or `'upper'`, a one-sided confidence level is required.
+        interval_type:
             Type of the confidence interval.
 
-            - `two-sided`: Two-sided confidence interval $(L, U)$.
-            - `lower`: Lower one-sided confidence interval $(L, +\\infty)$.
-            - `upper`: Upper one-sided confidence interval $(-\\infty, U)$.
-        method (Literal["clopper-pearson", "wald", "wilson"], optional):
-            Method used in calculation of the confidence interval.
-        continuity_correction (bool | None, optional):
-            Whether or not to apply Yate's continuity correction, only valid for `method='wald'` or `method='wilson'`.
-        search_direction (Literal["below", "above"], optional):
-            Direction of the search.
+            - `'two-sided'`: Two-sided confidence interval.
+            - `'lower'`: Lower one-sided confidence interval.
+            - `'upper'`: Upper one-sided confidence interval.
+        method:
+            The method used to construct the confidence interval.
 
-            - `'below'`: search for the proportion in range (0, 0.5]
-            - `'above'`: search for the proportion in range [0.5, 1)
+            - `'wald'`: Wald method.
+            - `'wilson'`: Wilson method.
+            - `'clopper-pearson'`, `'cp'`: Clopper-Pearson method.
+        continuity_correction:
+            Whether to apply the continuity correction, only takes effect when `method` is specified as `'wald'` or `'wilson'`
+        direction:
+            The search direction for the proportion relative to the 0.5.
+
+            - `'greater'`: Search for the proportion greater than 0.5.
+            - `'less'`: Search for the proportion less than 0.5.
 
     Returns:
-        (float): The required proportion.
+        float: The required proportion.
     """
 
     def func(proportion: float) -> float:
         return _distance(proportion, size, conf_level, interval_type, method, continuity_correction) - distance
 
-    match search_direction.lower():
-        case "below":
-            proportion = brentq(func, 0.000001, 0.5 + 0.000001)
-        case "above":
-            proportion = brentq(func, 0.5 - 0.000001, 0.999999)
-
-    return proportion
+    if abs(func(0.5)) < 1e-9:
+        return 0.5
+    else:
+        match direction:
+            case "greater":
+                return float(brentq(func, 0.5, 1 - 1e-12))
+            case "less":
+                return float(brentq(func, 1e-12, 0.5))

--- a/tests/test_proportion/test_single/test_ci.py
+++ b/tests/test_proportion/test_single/test_ci.py
@@ -4,76 +4,27 @@
 from dataclasses import dataclass
 from typing import Literal
 
-import pytest
 
 from pystatpower.proportion.single.ci import solve_distance, solve_proportion, solve_size
 
 from tests.models import BaseTestCase
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TestCase(BaseTestCase):
     proportion: float
     size: int
-    distance: float
-    actual_distance: float
     conf_level: float
     interval_type: Literal["two-sided", "lower", "upper"]
-    method: Literal["clopper-pearson", "wald", "wilson"]
+    method: Literal["wald", "wilson", "clopper-pearson", "cp"]
     continuity_correction: bool | None = None
+    distance: float
+    actual_distance: float
 
 
-case_group = (
+case_group_wald = (
     [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "clopper-pearson"
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="clopper-pearson")
-        for size, distance, actual_distance in [
-            (14029, 0.01, 0.0100),
-            (3557, 0.02, 0.0200),
-            (1603, 0.03, 0.0300),
-            (914, 0.04, 0.0400),
-            (593, 0.05, 0.0500),
-            (417, 0.06, 0.0600),
-            (310, 0.07, 0.0700),
-            (241, 0.08, 0.0798),
-            (192, 0.09, 0.0900),
-            (158, 0.10, 0.0997),
-        ]
-    ]
-    + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "clopper-pearson"
-        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="clopper-pearson")
-        for size, distance, actual_distance in [
-            (2704, 0.01, 0.0100),
-            (742, 0.02, 0.0200),
-            (359, 0.03, 0.0300),
-            (218, 0.04, 0.0399),
-            (150, 0.05, 0.0498),
-            (111, 0.06, 0.0598),
-            (86, 0.07, 0.0700),
-            (70, 0.08, 0.0796),
-            (58, 0.09, 0.0898),
-            (50, 0.10, 0.0988),
-        ]
-    ]
-    + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "clopper-pearson"
-        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="clopper-pearson")
-        for size, distance, actual_distance in [
-            (4298, 0.01, 0.0100),
-            (1065, 0.02, 0.0200),
-            (469, 0.03, 0.0300),
-            (261, 0.04, 0.0399),
-            (165, 0.05, 0.0499),
-            (113, 0.06, 0.0598),
-            (81, 0.07, 0.0699),
-            (61, 0.08, 0.0797),
-            (47, 0.09, 0.0897),
-            (37, 0.10, 0.0997),
-        ]
-    ]
-    + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wald", continuity_correction = False
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wald", continuity_correction = False
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="wald", continuity_correction=False)
         for size, distance, actual_distance in [
             (13830, 0.01, 0.0100),
@@ -89,7 +40,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wald", continuity_correction = False
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wald", continuity_correction = False
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wald", continuity_correction=False)
         for size, distance, actual_distance in [
             (2435, 0.01, 0.0100),
@@ -105,7 +56,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wald", continuity_correction = False
+        # proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wald", continuity_correction = False
         TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wald", continuity_correction=False)
         for size, distance, actual_distance in [
             (4329, 0.01, 0.0100),
@@ -120,8 +71,11 @@ case_group = (
             (44, 0.10, 0.0992),
         ]
     ]
-    + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wald", continuity_correction = True
+)
+
+case_group_wald_cc = (
+    [
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wald", continuity_correction = True
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="wald", continuity_correction=True)
         for size, distance, actual_distance in [
             (14029, 0.01, 0.0100),
@@ -137,7 +91,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wald", continuity_correction = True
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wald", continuity_correction = True
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wald", continuity_correction=True)
         for size, distance, actual_distance in [
             (2535, 0.01, 0.0100),
@@ -153,7 +107,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wald", continuity_correction = True
+        # proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wald", continuity_correction = True
         TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wald", continuity_correction=True)
         for size, distance, actual_distance in [
             (4429, 0.01, 0.0100),
@@ -168,8 +122,11 @@ case_group = (
             (53, 0.10, 0.0998),
         ]
     ]
-    + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wilson", continuity_correction = False
+)
+
+case_group_wilson = (
+    [
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wilson", continuity_correction = False
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="wilson", continuity_correction=False)
         for size, distance, actual_distance in [
             (13833, 0.01, 0.0100),
@@ -185,7 +142,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wilson", continuity_correction = False
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wilson", continuity_correction = False
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wilson", continuity_correction=False)
         for size, distance, actual_distance in [
             (2649, 0.01, 0.0100),
@@ -201,7 +158,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wilson", continuity_correction = False
+        # proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wilson", continuity_correction = False
         TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wilson", continuity_correction=False)
         for size, distance, actual_distance in [
             (4164, 0.01, 0.0100),
@@ -216,8 +173,11 @@ case_group = (
             (25, 0.10, 0.0991),
         ]
     ]
-    + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wilson", continuity_correction = True
+)
+
+case_group_wilson_cc = (
+    [
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wilson", continuity_correction = True
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="wilson", continuity_correction=True)
         for size, distance, actual_distance in [
             (14032, 0.01, 0.0100),
@@ -233,7 +193,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wilson", continuity_correction = True
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "wilson", continuity_correction = True
         TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="wilson", continuity_correction=True)
         for size, distance, actual_distance in [
             (2748, 0.01, 0.0100),
@@ -249,7 +209,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wilson", continuity_correction = True
+        # proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "wilson", continuity_correction = True
         TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="wilson", continuity_correction=True)
         for size, distance, actual_distance in [
             (4264, 0.01, 0.0100),
@@ -265,7 +225,7 @@ case_group = (
         ]
     ]
     + [
-        # Regular Cases: proportion = 0.10, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wilson", continuity_correction = True
+        # proportion = 0.10, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "wilson", continuity_correction = True
         TestCase(proportion=0.10, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="wilson", continuity_correction=True)
         for size, distance, actual_distance in [
             (14032, 0.01, 0.0100),
@@ -282,24 +242,58 @@ case_group = (
     ]
 )
 
+case_group_cp = (
+    [
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "two-sided", method = "clopper-pearson"
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="two-sided", method="clopper-pearson")
+        for size, distance, actual_distance in [
+            (14029, 0.01, 0.0100),
+            (3557, 0.02, 0.0200),
+            (1603, 0.03, 0.0300),
+            (914, 0.04, 0.0400),
+            (593, 0.05, 0.0500),
+            (417, 0.06, 0.0600),
+            (310, 0.07, 0.0700),
+            (241, 0.08, 0.0798),
+            (192, 0.09, 0.0900),
+            (158, 0.10, 0.0997),
+        ]
+    ]
+    + [
+        # proportion = 0.90, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "lower", method = "clopper-pearson"
+        TestCase(proportion=0.90, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="lower", method="clopper-pearson")
+        for size, distance, actual_distance in [
+            (2704, 0.01, 0.0100),
+            (742, 0.02, 0.0200),
+            (359, 0.03, 0.0300),
+            (218, 0.04, 0.0399),
+            (150, 0.05, 0.0498),
+            (111, 0.06, 0.0598),
+            (86, 0.07, 0.0700),
+            (70, 0.08, 0.0796),
+            (58, 0.09, 0.0898),
+            (50, 0.10, 0.0988),
+        ]
+    ]
+    + [
+        # proportion = 0.80, distance = 0.01 to 0.10 by 0.01, conf_level = 0.95, interval_type = "upper", method = "clopper-pearson"
+        TestCase(proportion=0.80, size=size, distance=distance, actual_distance=actual_distance, conf_level=0.95, interval_type="upper", method="clopper-pearson")
+        for size, distance, actual_distance in [
+            (4298, 0.01, 0.0100),
+            (1065, 0.02, 0.0200),
+            (469, 0.03, 0.0300),
+            (261, 0.04, 0.0399),
+            (165, 0.05, 0.0499),
+            (113, 0.06, 0.0598),
+            (81, 0.07, 0.0699),
+            (61, 0.08, 0.0797),
+            (47, 0.09, 0.0897),
+            (37, 0.10, 0.0997),
+        ]
+    ]
+)
 
-def test_solve_size(case: TestCase) -> None:
-    assert (
-        solve_size(
-            proportion=case.proportion,
-            distance=case.distance,
-            conf_level=case.conf_level,
-            interval_type=case.interval_type,
-            method=case.method,
-            continuity_correction=case.continuity_correction,
-        )
-        == case.size
-    )
-
-
-def test_solve_size_no_solution() -> None:
-    with pytest.raises(ValueError):
-        assert solve_size(proportion=0.90, distance=0.99, conf_level=0.95, method="wilson", continuity_correction=True)
+case_group = case_group_wald + case_group_wald_cc + case_group_wilson + case_group_wilson_cc + case_group_cp
 
 
 def test_solve_distance(case: TestCase) -> None:
@@ -319,8 +313,37 @@ def test_solve_distance(case: TestCase) -> None:
     )
 
 
+def test_solve_size(case: TestCase) -> None:
+    assert (
+        solve_size(
+            proportion=case.proportion,
+            distance=case.distance,
+            conf_level=case.conf_level,
+            interval_type=case.interval_type,
+            method=case.method,
+            continuity_correction=case.continuity_correction,
+        )
+        == case.size
+    )
+
+
+def test_solve_size_wilson_score_cc_return_2() -> None:
+    assert solve_size(proportion=0.90, distance=0.90, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.91, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.92, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.93, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.94, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.95, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.96, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.97, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.98, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+    assert solve_size(proportion=0.90, distance=0.99, conf_level=0.95, method="wilson", continuity_correction=True) == 2
+
+
 def test_solve_proportion(case: TestCase) -> None:
-    side = "below" if case.proportion < 0.5 else "above"
+
+    direction = "greater" if case.proportion > 0.5 else "less"
+
     assert (
         round(
             solve_proportion(
@@ -330,9 +353,17 @@ def test_solve_proportion(case: TestCase) -> None:
                 interval_type=case.interval_type,
                 method=case.method,
                 continuity_correction=case.continuity_correction,
-                search_direction=side,
+                direction=direction,
             ),
             2,
         )
         == case.proportion
     )
+
+
+def test_solve_proportion_exact_eq_0_5() -> None:
+    assert solve_proportion(size=385, distance=0.099889014, conf_level=0.95, interval_type="two-sided", method="wald") == 0.5
+    assert solve_proportion(size=404, distance=0.099987100, conf_level=0.95, interval_type="two-sided", method="wald", continuity_correction=True) == 0.5
+    assert solve_proportion(size=381, distance=0.099909587, conf_level=0.95, interval_type="two-sided", method="wilson") == 0.5
+    assert solve_proportion(size=401, distance=0.099880264, conf_level=0.95, interval_type="two-sided", method="wilson", continuity_correction=True) == 0.5
+    assert solve_proportion(size=402, distance=0.099930088, conf_level=0.95, interval_type="two-sided", method="cp") == 0.5


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation, Bug fix


___

### **Description**
- Refactored all proportion CI distance functions (Wald, Wilson, Clopper-Pearson) for performance and clarity.

- Added `_domain_square_root_of_quad` math utility to handle domain constraints in Wilson continuity correction.

- Changed `solve_proportion` API: renamed `search_direction` to `direction` with values "greater"/"less".

- Improved docstrings across the module and updated test structure with separate method groups.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_math_utils.py: new utility function"] --> B["ci.py: used in solve_size for Wilson CC"]
  C["ci.py: refactored distance functions"] --> D["cleaner code, same logic"]
  E["ci.py: updated API parameter"] --> F["search_direction -> direction"]
  G["test_ci.py: reorganized tests"] --> H["separate groups + new tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_math_utils.py</strong><dd><code>Added math utility for quadratic domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/_math_utils.py

<ul><li>New module with one function <code>_domain_square_root_of_quad</code>.<br> <li> Solves domain of <code>sqrt(ax^2+bx+c)</code>, used for Wilson continuity <br>correction sample size search.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/463/files#diff-a1971f2e6b617511d10ecbe710c1cfbc6c19412ec1578538a298feac1518cd7d">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci.py</strong><dd><code>Refactored CI module with new utility and cleaner code</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/single/ci.py

<ul><li>Refactored all distance functions: reused intermediate variables <br>(alpha, se, z) and renamed formulas.<br> <li> Updated <code>_distance</code> to accept "cp" as alias for "clopper-pearson".<br> <li> Improved docstrings and type hints; standardized parameter <br>descriptions.<br> <li> Reworked <code>solve_size</code> for Wilson CC: uses new utility, returns 2 instead <br>of raising error.<br> <li> Changed <code>solve_proportion</code> API: <code>search_direction</code> -> <code>direction</code> (values <br>"greater"/"less").<br> <li> Removed import of <code>SAMPLE_SIZE_SEARCH_MAX</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/463/files#diff-cf0b984c0d1673d5ec89623683697dbebfe7e4cbc4e9108c01843a7ad873b2fc">+265/-228</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ci.py</strong><dd><code>Reorganized tests and added new edge case tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_proportion/test_single/test_ci.py

<ul><li>Reorganized test cases into separate groups per method (wald, wilson, <br>cp).<br> <li> Removed <code>pytest</code> import and <code>test_solve_size_no_solution</code> test.<br> <li> Added <code>test_solve_size_wilson_score_cc_return_2</code> for new behavior.<br> <li> Updated <code>test_solve_proportion</code> to use <code>direction</code> parameter and added <br>test for exact 0.5 proportion.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/463/files#diff-65b7ff0406b8576a38d942dfc218abafde8b6aaac2e1d184862746b62aff87a4">+120/-90</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

