### PR TITLE
docs(algo): optimize docs of `proportion.single.inequality`

### DIFF
--- a/docs/algorithms/proportion/single/inequality.md
+++ b/docs/algorithms/proportion/single/inequality.md
@@ -1,6 +1,8 @@
 # 单样本率差异性检验
 
-## Z-test using S(P0) {#z-test-p0}
+样本率用 $\hat{p}$ 表示，总体率用 $p$ 表示。
+
+对于双侧检验，统计学假设如下：
 
 $$
 \begin{align}
@@ -9,118 +11,176 @@ H_1 & : p \neq p_0
 \end{align}
 $$
 
-在 $H_0$ 成立时，样本比例 $\hat{p}$ 服从近似正态分布：
+对于左单侧检验，统计学假设如下：
 
 $$
-\hat{p} \sim N\left(p_0,\ \frac{p_0(1-p0)}{n}\right)
+\begin{align}
+H_0 & : p \geqslant p_0 \\
+H_1 & : p \lt p_0
+\end{align}
 $$
 
-那么：
+对于右单侧检验，统计学假设如下：
 
 $$
-E(\hat{p} - p_0) = E(\hat{p}) - p_0 = p_0 - p_0 = 0
+\begin{align}
+H_0 & : p \leqslant p_0 \\
+H_1 & : p \gt p_0
+\end{align}
 $$
 
-$$
-Var(\hat{p} - p_0) = Var(\hat{p}) = \frac{p_0(1-p_0)}{n}
-$$
+以下推导过程在边界条件 $p = p_0$ 下进行。
 
-构建 $z$ 统计量：
+## _z-test using s(p0)_ {#z-test-p0}
 
-$$
-z = \frac{\hat{p} - p_0}{\sqrt{p_0(1-p_0)/n}} \sim N(0, 1)
-$$
-
-拒绝 $H_0$ 的条件：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
-z > z_{1-\alpha/2}
+z = \frac{\hat{p}-p_0}{\sqrt{p_0(1-p_0)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，可构建统计量：
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
 
 $$
-z' = \frac{\hat{p} - p_0}{\sqrt{p_0(1-p_0)/n}} = \frac{\sqrt{n}(\hat{p} - p_0)}{\sqrt{p_0(1-p_0)}}
+z' = \frac{\hat{p}-p_0}{\sqrt{p_0(1-p_0)/n}} \sim N\left(\frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}, \frac{p(1-p)}{p_0(1-p_0)}\right)
 $$
 
-根据中心极限定理，当 $n$ 较大时，样本比例 $\hat{p}$ 满足：
-
-$$
-\sqrt{n}(\hat{p} - p_1) \xrightarrow{d} N(0, p_1(1-p_1))
-$$
-
-即 $\sqrt{n}\left(\hat{p} - p_1\right)$ 依分布收敛到均值为 $0$，方差为 $p_1(1-p_1)$ 的正态分布，进而有：
-
-$$
-z' = \frac{\sqrt{n}(\hat{p} - p_0)}{\sqrt{p_0(1-p_0)}} = \frac{\sqrt{n}(\hat{p} - p_1) + \sqrt{n}(p_1 - p_0)}{\sqrt{p_0(1-p_0)}} \xrightarrow{d} N\left( \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_0(1-p_0)}}, \frac{p_1(1-p_1)}{p_0(1-p_0)} \right)
-$$
-
-根据检验类型分类讨论：
-
-!!! note "单侧检验，$p_1 > p_0$"
+=== "双侧检验"
 
     $$
-    \begin{align}
-        P\left(z' > z_{1-\alpha} \right)
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} - \sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 1 - \beta
-    \end{align}
+    \text{Power} = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < z_{\alpha/2} \right)
+                 = 1 - \Phi\left(\frac{z_{1-\alpha/2} - \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
+                     + \Phi\left(\frac{z_{\alpha/2} - \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
     $$
 
-!!! note "单侧检验，$p_1 < p_0$"
+=== "左单侧检验"
 
     $$
-    \begin{align}
-        P\left(z' < -z_{1-\alpha} \right)
-    & = \Phi\left( \frac{-z_{1-\alpha} - \frac{\sqrt{n} (p_1-p_0)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} + \sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 1 - \beta
-    \end{align}
+    \text{Power} = P\left(z' < z_{\alpha} \right)
+                 = \Phi\left(\frac{z_{\alpha} - \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
     $$
 
-!!! note "双侧检验，$p_1 \neq p_0$"
+=== "右单侧检验"
 
     $$
-    \begin{align}
-        P\left( \left| z' \right| > z_{1-\alpha/2} \right)
-    & = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < -z_{1-\alpha/2} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right)
-          + \Phi\left( \frac{-z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} - \sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) +
-        1 - \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} + \sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 2 - \left[
-                  \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} - \sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) +
-                  \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} + \sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right)
-            \right] \\
-    & = 1 - \beta
-    \end{align}
+    \text{Power} = P\left(z' > z_{1-\alpha} \right)
+                 = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
     $$
 
-!!! example "以单侧检验为例，推导样本量计算公式"
+??? note "单侧检验样本量公式推导"
 
     根据标准正态分布分位数的定义：
 
     $$
-    \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} - \sqrt{n}|p_1-p_0|}{\sqrt{p_1(1-p_1)}} = z_{\beta}
+    \frac{z_{1-\alpha} \pm \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}} = \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} \pm \sqrt{n}(p_1-p_0)}{\sqrt{p(1-p)}} = z_{\beta}
     $$
 
     可解出：
 
     $$
-    n = \frac{\left( z_{1-\alpha} \sqrt{p_0(1-p_0)} + z_{1-\beta} \sqrt{p_1(1-p_1)} \right)^2}{\left( p_1 - p_0 \right)^2}
+    n = \frac{\left(z_{1-\alpha}\sqrt{p_0(1-p_0)} + z_{1-\beta}\sqrt{p(1-p)}\right)^2}{\left(p-p_0\right)^2}
     $$
 
+## _z-test using s(p0) with continuity correction_ {#z-test-p0-cc}
 
-## Z-test using S(P0) 连续性校正 {#z-test-p0-cc}
-
-在 [Z-test using S(P0)](#z-test-p0) 的基础上加入校正项 $c$：
+在 [_z-test using s(p0)_](#z-test-p0) 的基础上加入校正项 $c$：
 
 $$
-z = \frac{\hat{p} - p_0 + c}{\sqrt{p_0(1-p_0)/n}} \sim N(0, 1)
+c =
+\begin{cases}
+- \frac{1}{2n} & , \text{if } \hat{p} \gt p_0 \\
+  \frac{1}{2n} & , \text{if } \hat{p} \lt p_0 \\
+  0            & , \text{if } \left| \hat{p} - p_0 \right| \leqslant \frac{1}{2n}
+\end{cases}
 $$
 
-其中：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
+
+$$
+z = \frac{\hat{p}-p_0+c}{\sqrt{p_0(1-p_0)/n}} \sim N(0, 1)
+$$
+
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
+
+$$
+z' = \frac{\hat{p}-p_0+c}{\sqrt{p_0(1-p_0)/n}} \sim N\left(\frac{\hat{p}-p_0+c}{\sqrt{p_0(1-p_0)/n}}, \frac{p(1-p)}{p_0(1-p_0)}\right)
+$$
+
+=== "双侧检验"
+
+    $$
+    \text{Power} = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < z_{\alpha/2} \right)
+                 = 1 - \Phi\left(\frac{z_{1-\alpha/2} - \frac{p-p_0+c}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
+                     + \Phi\left(\frac{z_{\alpha/2} - \frac{p-p_0+c}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
+    $$
+
+=== "左单侧检验"
+
+    $$
+    \text{Power} = P\left(z' < z_{\alpha} \right)
+                 = \Phi\left(\frac{z_{\alpha} - \frac{p-p_0+c}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
+    $$
+
+=== "右单侧检验"
+
+    $$
+    \text{Power} = P\left(z' > z_{1-\alpha} \right)
+                 = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0+c}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}}\right)
+    $$
+
+## _z-test using s(phat)_ {#z-test-phat}
+
+在 $H_0$ 成立时，可构建 $z$ 统计量：
+
+$$
+z = \frac{\hat{p}-p_0}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N(0, 1)
+$$
+
+在 $H_1$ 成立时，可构建 $z'$ 统计量:
+
+$$
+z' = \frac{\hat{p}-p_0}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N\left(\frac{p-p_0}{\sqrt{p(1-p)/n}}, 1\right)
+$$
+
+=== "双侧检验"
+
+    $$
+    \text{Power} = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < z_{\alpha/2} \right)
+                 = 1 - \Phi\left(z_{1-\alpha/2} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
+                     + \Phi\left(z_{\alpha/2} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
+    $$
+
+=== "左单侧检验"
+
+    $$
+    \text{Power} = P\left(z' < z_{\alpha/2} \right)
+                 = \Phi\left(z_{\alpha/2} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
+    $$
+
+=== "右单侧检验"
+
+    $$
+    \text{Power} = P\left(z' > z_{1-\alpha/2} \right)
+                 = 1 - \Phi\left(z_{1-\alpha/2} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
+    $$
+
+??? note "单侧检验样本量公式推导"
+
+    根据标准正态分布分位数的定义：
+
+    $$
+    z_{1-\alpha/2} \pm \frac{p-p_0}{\sqrt{p(1-p)/n}} = z_{\beta}
+    $$
+
+    可解出：
+
+    $$
+    n = \frac{\left(z_{1-\alpha/2}+z_{1-\beta}\right)^2 p(1-p)}{\left(p-p_0\right)^2}
+    $$
+
+## _z-test using s(phat) with continuity correction_ {#z-test-phat-cc}
+
+在 [_z-test using s(phat)_](#z-test-phat) 的基础上加入校正项 $c$：
 
 $$
 c =
@@ -131,366 +191,36 @@ c =
 \end{cases}
 $$
 
-在 $H_1$ 成立时，可构建统计量：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
-z' = \frac{\hat{p} - p_0 + c}{\sqrt{p_0(1-p_0)/n}} = \frac{\sqrt{n}(\hat{p} - p_0 + c)}{\sqrt{p_0(1-p_0)}}
+z = \frac{\hat{p}-p_0+c}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N(0, 1)
 $$
 
-根据中心极限定理，当 $n$ 较大时，样本比例 $\hat{p}$ 满足：
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
 
 $$
-\sqrt{n}(\hat{p} - p_1) \xrightarrow{d} N(0, p_1(1-p_1))
+z' = \frac{\hat{p}-p_0+c}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N\left(\frac{p-p_0+c}{\sqrt{p(1-p)/n}}, 1\right)
 $$
 
-即 $\sqrt{n}\left(\hat{p} - p_1\right)$ 依分布收敛到均值为 $0$，方差为 $p_1(1-p_1)$ 的正态分布，进而有：
-
-$$
-z' =  \frac{\sqrt{n}(\hat{p} - p_1) + \sqrt{n}(p_1 - p_0 + c)}{\sqrt{p_0(1-p_0)}} \xrightarrow{d} N\left( \frac{\sqrt{n}(p_1-p_0+c)}{\sqrt{p_0(1-p_0)}}, \frac{p_1(1-p_1)}{p_0(1-p_0)} \right)
-$$
-
-根据检验类型分类讨论：
-
-!!! note "单侧检验，$p_1 > p_0$"
+=== "双侧检验"
 
     $$
-    \begin{align}
-        P\left(z' > z_{1-\alpha} \right)
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} - \frac{\sqrt{n} \left(p_1-p_0-\frac{1}{2n} \right)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} - \sqrt{n} \left(p_1-p_0-\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 1 - \beta
-    \end{align}
+    \text{Power} = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < z_{\alpha/2} \right)
+                 = 1 - \Phi\left(z_{1-\alpha/2} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
+                     + \Phi\left(z_{\alpha/2} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
     $$
 
-!!! note "单侧检验，$p_1 < p_0$"
+=== "左单侧检验"
 
     $$
-    \begin{align}
-        P\left(z' < -z_{1-\alpha} \right)
-    & = \Phi\left( \frac{-z_{1-\alpha} - \frac{\sqrt{n} \left(p_1-p_0+\frac{1}{2n} \right)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} + \frac{\sqrt{n} \left(p_1-p_0+\frac{1}{2n} \right)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} + \sqrt{n} \left(p_1-p_0+\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 1 - \beta
-    \end{align}
+    \text{Power} = P\left(z' < z_{\alpha/2} \right)
+                 = \Phi\left(z_{\alpha/2} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
     $$
 
-!!! note "双侧检验，$p_1 \neq p_0$"
+=== "右单侧检验"
 
     $$
-    \begin{align}
-        P\left( \left| z' \right| > z_{1-\alpha/2} \right)
-    & = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < -z_{1-\alpha/2} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha/2} - \frac{\sqrt{n} \left(p_1-p_0-\frac{1}{2n} \right)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right)
-          + \Phi\left( \frac{-z_{1-\alpha/2} - \frac{\sqrt{n} \left(p_1-p_0+\frac{1}{2n} \right)}{\sqrt{p_0(1-p_0)}}}{\sqrt{\frac{p_1(1-p_1)}{p_0(1-p_0)}}} \right) \\
-    & = 1 - \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} - \sqrt{n} \left(p_1-p_0-\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} \right) +
-        1 - \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} + \sqrt{n} \left(p_1-p_0+\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 2 - \left[
-                  \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} - \sqrt{n} \left(p_1-p_0-\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} \right) +
-                  \Phi\left( \frac{z_{1-\alpha/2} \sqrt{p_0(1-p_0)} + \sqrt{n} \left(p_1-p_0+\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} \right)
-            \right] \\
-    & = 1 - \beta
-    \end{align}
-    $$
-
-??? example "以单侧检验为例，推导样本量计算公式"
-
-    根据标准正态分布分位数的定义：
-
-    $$
-    \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} - \sqrt{n} \left( \left| p_1-p_0 \right| - \frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} = z_{\beta} \Rightarrow z_{1-\alpha} \sqrt{p_0(1-p_0)} + z_{1-\beta} \sqrt{p_1(1-p_1)} = \sqrt{n} \left(| p_1 - p_0| - \frac{1}{2n}\right)
-    $$
-
-    令 $A = z_{1-\alpha} \sqrt{p_0(1-p_0)} + z_{1-\beta} \sqrt{p_1(1-p_1)}$，$\delta = | p_1 - p_0|$，则：
-
-    $$
-    A = \sqrt{n} \left(\delta - \frac{1}{2n}\right) \Rightarrow A\sqrt{n} = \delta  n - \frac{1}{2} \Rightarrow \delta n - A\sqrt{n} - \frac{1}{2} = 0
-    $$
-
-    令 $x = \sqrt{n}$，则：
-
-    $$
-    \delta x^2 - Ax - \frac{1}{2} = 0 \Rightarrow x = \frac{A \pm \sqrt{A^2 + 2\delta}}{2\delta}
-    $$
-
-    由于 $A \gt 0$，$\delta \gt 0$，故取正根：
-
-    $$
-    x = \frac{A + \sqrt{A^2 + 2\delta}}{2\delta}
-    $$
-
-    $$
-    n = x^2 = \left( \frac{A + \sqrt{A^2 + 2\delta}}{2\delta} \right)^2 \tag{2.1}
-    $$
-
-    引入未经校正的样本量 $n'$：
-
-    $$
-    n' = \frac{A^2}{\delta^2}
-    $$
-
-    即 $A = \delta\sqrt{n'}$，代入式 $(2.1)$：
-
-    $$
-    \begin{align}
-    n & = \left( \frac{\delta\sqrt{n'} + \sqrt{\delta^2 n' + 2\delta}}{2\delta} \right)^2 \\
-    & = \frac{\delta^2 \left(\sqrt{n'} + \sqrt{n' + \frac{2}{\delta}}\right)^2}{4\delta^2} \\
-    & = \frac{n'}{4} \left( 1 + \sqrt{1 + \frac{2}{\delta n'}}\right)^2
-    \end{align}
-    $$
-
-    故：
-
-    $$
-    n = \frac{n'}{4} \left( 1 + \sqrt{1 + \frac{2}{|p_1 - p_0| n'}}\right)^2
-    $$
-
-
-## Z-test using S(Phat) {#z-test-phat}
-
-
-$$
-\begin{align}
-H_0 & : p = p_0 \\
-H_1 & : p \neq p_0
-\end{align}
-$$
-
-在 $H_0$ 成立时：
-
-$$
-E(\hat{p} - p_0) = E(\hat{p}) - p_0 = p_0 - p_0 = 0
-$$
-
-$$
-Var(\hat{p} - p_0) = Var(\hat{p}) = \frac{\hat{p}(1-\hat{p})}{n}
-$$
-
-构建 $z$ 统计量：
-
-$$
-z = \frac{\hat{p} - p_0}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N(0, 1)
-$$
-
-拒绝 $H_0$ 的条件：
-
-$$
-z > z_{1-\alpha/2}
-$$
-
-在 $H_1$ 成立时，可构建统计量:
-
-$$
-z' = \frac{\hat{p} - p_0}{\sqrt{\hat{p}\left(1 - \hat{p}\right) / n}} = \frac{\sqrt{n}\left(\hat{p} - p_0\right)}{\sqrt{\hat{p}\left(1 - \hat{p}\right)}}
-$$
-
-根据中心极限定理，当 $n$ 较大时，样本比例 $\hat{p}$ 满足：
-
-$$
-\sqrt{n}\left(\hat{p} - p_1\right) \xrightarrow{d} N\left(0, p_1(1-p_1)\right)
-$$
-
-即 $\sqrt{n}\left(\hat{p} - p_1\right)$ 依分布收敛到均值为 $0$，方差为 $p_1(1-p_1)$ 的正态分布，进而有：
-
-$$
-\sqrt{n}\left(\hat{p} - p_0\right) = \sqrt{n}\left(\hat{p} - p_1\right) + \sqrt{n}\left(p_1 - p_0\right) \xrightarrow{d} N\left(\sqrt{n}(p_1-p_0), p_1(1-p_1)\right)\tag{3.1}
-$$
-
-根据大数定律和连续映射定理：
-
-$$
-\sqrt{\hat{p}\left(1 - \hat{p}\right)} \xrightarrow{p} \sqrt{p_1\left(1-p_1\right)} \tag{3.2}
-$$
-
-由 $(3.1), (3.2)$，基于 Slutsky 定理：
-
-$$
-z' \xrightarrow{d} N\left(\frac{\sqrt{n}(p_1 - p_0)}{\sqrt{p_1(1-p_1)}}, 1\right)
-$$
-
-根据检验类型分类讨论：
-
-!!! note "单侧检验，$p_1 > p_0$"
-
-    $$
-    P\left(z' > z_{1-\alpha} \right) = 1 - \Phi\left( z_{1-\alpha} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) = 1 - \beta
-    $$
-
-!!! note "单侧检验，$p_1 < p_0$"
-
-    $$
-      P\left(z' < -z_{1-\alpha} \right)
-    = \Phi\left( -z_{1-\alpha} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right)
-    = 1 - \Phi\left( z_{1-\alpha} + \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right)
-    = 1 - \beta
-    $$
-
-!!! note "双侧检验，$p_1 \neq p_0$"
-
-    $$
-    \begin{align}
-        P\left( \left| z' \right| > z_{1-\alpha/2} \right)
-    & = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < -z_{1-\alpha/2} \right) \\
-    & = 1 - \Phi\left( z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right)
-          + \Phi\left( -z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 1 - \Phi\left( z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) +
-        1 - \Phi\left( z_{1-\alpha/2} + \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 2 - \left[
-                  \Phi\left( z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right) +
-                  \Phi\left( z_{1-\alpha/2} + \frac{\sqrt{n}(p_1-p_0)}{\sqrt{p_1(1-p_1)}} \right)
-            \right] \\
-    & = 1 - \beta
-    \end{align}
-    $$
-
-!!! example "以单侧检验为例，推导样本量计算公式"
-
-    根据标准正态分布分位数的定义：
-
-    $$
-    z_{1-\alpha/2} - \frac{\sqrt{n} \left| p_1 - p_0 \right|}{\sqrt{p_1(1-p_1)}} = z_{\beta}
-    $$
-
-    可解出：
-
-    $$
-    n = \frac{\left( z_{1-\alpha/2} + z_{1-\beta} \right)^2 p_1(1-p_1)}{\left(p_1-p_0\right)^2}
-    $$
-
-
-## Z-test using S(Phat) 连续性校正 {z-test-phat-cc}
-
-在 [Z-test using S(Phat)](#z-test-phat) 的基础上加入校正项 $c$：
-
-
-$$
-z = \frac{\hat{p} - p_0 + c}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N(0, 1)
-$$
-
-其中：
-
-$$
-c =
-\begin{cases}
-- \frac{1}{2n} & , \text{if } \hat{p} \gt p_0 \\
-  \frac{1}{2n} & , \text{if } \hat{p} \lt p_0 \\
-  0            & , \text{if } \left| \hat{p} - p_0 \right| \le \frac{1}{2n}
-\end{cases}
-$$
-
-在 $H_1$ 成立时，可构建统计量：
-
-$$
-z' = \frac{\hat{p} - p_0 + c}{\sqrt{\hat{p}(1-\hat{p})/n}} = \frac{\sqrt{n}(\hat{p} - p_0 + c)}{\sqrt{\hat{p}(1-\hat{p})}}
-$$
-
-根据中心极限定理，当 $n$ 较大时，样本比例 $\hat{p}$ 满足：
-
-$$
-\sqrt{n}(\hat{p} - p_1) \xrightarrow{d} N(0, p_1(1-p_1))
-$$
-
-即 $\sqrt{n}\left(\hat{p} - p_1\right)$ 依分布收敛到均值为 $0$，方差为 $p_1(1-p_1)$ 的正态分布，进而有：
-
-$$
-\sqrt{n}\left(\hat{p} - p_0 + c\right) = \sqrt{n}\left(\hat{p} - p_1\right) + \sqrt{n}\left(p_1 - p_0 + c\right) \xrightarrow{d} N\left(\sqrt{n}(p_1 - p_0 + c), p_1(1-p_1)\right) \tag{4.1}
-$$
-
-根据大数定律和连续映射定理：
-
-$$
-\sqrt{\hat{p}\left(1 - \hat{p}\right)} \xrightarrow{p} \sqrt{p_1\left(1-p_1\right)} \tag{4.2}
-$$
-
-由 $(4.1), (4.2)$，基于 Slutsky 定理：
-
-$$
-z' \xrightarrow{d} N\left(\frac{\sqrt{n}(p_1 - p_0 + c)}{\sqrt{p_1(1-p_1)}}, 1\right)
-$$
-
-
-根据检验类型分类讨论：
-
-!!! note "单侧检验，$p_1 > p_0$"
-
-    $$
-    P\left(z' > z_{1-\alpha} \right) = 1 - \Phi\left( z_{1-\alpha} - \frac{\sqrt{n}(p_1-p_0-\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right) = 1 - \beta
-    $$
-
-!!! note "单侧检验，$p_1 < p_0$"
-
-    $$
-      P\left(z' < -z_{1-\alpha} \right)
-    = \Phi\left( -z_{1-\alpha} - \frac{\sqrt{n}(p_1-p_0+\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right)
-    = 1 - \Phi\left( z_{1-\alpha} + \frac{\sqrt{n}(p_1-p_0+\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right)
-    = 1 - \beta
-    $$
-
-!!! note "双侧检验，$p_1 \neq p_0$"
-
-    $$
-    \begin{align}
-        P\left( \left| z' \right| > z_{1-\alpha/2} \right)
-    & = P\left(z' > z_{1-\alpha/2} \right) + P\left(z' < -z_{1-\alpha/2} \right) \\
-    & = 1 - \Phi\left( z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0-\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right)
-          + \Phi\left( -z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0+\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 1 - \Phi\left( z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0-\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right) +
-        1 - \Phi\left( z_{1-\alpha/2} + \frac{\sqrt{n}(p_1-p_0+\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right) \\
-    & = 2 - \left[
-                  \Phi\left( z_{1-\alpha/2} - \frac{\sqrt{n}(p_1-p_0-\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right) +
-                  \Phi\left( z_{1-\alpha/2} + \frac{\sqrt{n}(p_1-p_0+\frac{1}{2n})}{\sqrt{p_1(1-p_1)}} \right)
-            \right] \\
-    & = 1 - \beta
-    \end{align}
-    $$
-
-??? example "以单侧检验为例，推导样本量计算公式"
-
-    根据标准正态分布分位数的定义：
-
-    $$
-    z_{1-\alpha} - \frac{\sqrt{n} \left( |p_1-p_0|-\frac{1}{2n} \right)}{\sqrt{p_1(1-p_1)}} = z_{\beta} \Rightarrow  \left(z_{1-\alpha} + z_{1-\beta}\right) \sqrt{p_1(1-p_1)} = \sqrt{n} \left(| p_1 - p_0| - \frac{1}{2n}\right)
-    $$
-
-    令 $A = \left(z_{1-\alpha} + z_{1-\beta}\right) \sqrt{p_1(1-p_1)}$，$\delta = | p_1 - p_0|$，则：
-
-    $$
-    A = \sqrt{n} \left(\delta - \frac{1}{2n}\right) \Rightarrow A\sqrt{n} = \delta  n - \frac{1}{2} \Rightarrow \delta n - A\sqrt{n} - \frac{1}{2} = 0
-    $$
-
-    令 $x = \sqrt{n}$，则：
-
-    $$
-    \delta x^2 - Ax - \frac{1}{2} = 0 \Rightarrow x = \frac{A \pm \sqrt{A^2 + 2\delta}}{2\delta}
-    $$
-
-    由于 $A \gt 0$，$\delta \gt 0$，故取正根：
-
-    $$
-    x = \frac{A + \sqrt{A^2 + 2\delta}}{2\delta}
-    $$
-
-    $$
-    n = x^2 = \left( \frac{A + \sqrt{A^2 + 2\delta}}{2\delta} \right)^2 \tag{2.1}
-    $$
-
-    引入未经校正的样本量 $n'$：
-
-    $$
-    n' = \frac{A^2}{\delta^2}
-    $$
-
-    即 $A = \delta\sqrt{n'}$，代入式 $(2.1)$：
-
-    $$
-    \begin{align}
-    n & = \left( \frac{\delta\sqrt{n'} + \sqrt{\delta^2 n' + 2\delta}}{2\delta} \right)^2 \\
-    & = \frac{\delta^2 \left(\sqrt{n'} + \sqrt{n' + \frac{2}{\delta}}\right)^2}{4\delta^2} \\
-    & = \frac{n'}{4} \left( 1 + \sqrt{1 + \frac{2}{\delta n'}}\right)^2
-    \end{align}
-    $$
-
-    故：
-
-    $$
-    n = \frac{n'}{4} \left( 1 + \sqrt{1 + \frac{2}{|p_1 - p_0| n'}}\right)^2
+    \text{Power} = P\left(z' > z_{1-\alpha/2} \right)
+                 = 1 - \Phi\left(z_{1-\alpha/2} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
     $$

--- a/docs/algorithms/proportion/single/inequality.md
+++ b/docs/algorithms/proportion/single/inequality.md
@@ -72,7 +72,7 @@ $$
     根据标准正态分布分位数的定义：
 
     $$
-    \frac{z_{1-\alpha} \pm \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}} = \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} \pm \sqrt{n}(p_1-p_0)}{\sqrt{p(1-p)}} = z_{\beta}
+    \frac{z_{1-\alpha} \pm \frac{p-p_0}{\sqrt{p_0(1-p_0)/n}}}{\sqrt{\frac{p(1-p)}{p_0(1-p_0)}}} = \frac{z_{1-\alpha} \sqrt{p_0(1-p_0)} \pm \sqrt{n}(p-p_0)}{\sqrt{p(1-p)}} = z_{\beta}
     $$
 
     可解出：
@@ -187,7 +187,7 @@ c =
 \begin{cases}
 - \frac{1}{2n} & , \text{if } \hat{p} \gt p_0 \\
   \frac{1}{2n} & , \text{if } \hat{p} \lt p_0 \\
-  0            & , \text{if } \left| \hat{p} - p_0 \right| \le \frac{1}{2n}
+  0            & , \text{if } \left| \hat{p} - p_0 \right| \leqslant \frac{1}{2n}
 \end{cases}
 $$
 

--- a/docs/algorithms/proportion/single/inequality.md
+++ b/docs/algorithms/proportion/single/inequality.md
@@ -103,7 +103,7 @@ $$
 在 $H_1$ 成立时，可构建 $z'$ 统计量：
 
 $$
-z' = \frac{\hat{p}-p_0+c}{\sqrt{p_0(1-p_0)/n}} \sim N\left(\frac{\hat{p}-p_0+c}{\sqrt{p_0(1-p_0)/n}}, \frac{p(1-p)}{p_0(1-p_0)}\right)
+z' = \frac{\hat{p}-p_0+c}{\sqrt{p_0(1-p_0)/n}} \sim N\left(\frac{p-p_0+c}{\sqrt{p_0(1-p_0)/n}}, \frac{p(1-p)}{p_0(1-p_0)}\right)
 $$
 
 === "双侧检验"
@@ -153,15 +153,15 @@ $$
 === "左单侧检验"
 
     $$
-    \text{Power} = P\left(z' < z_{\alpha/2} \right)
-                 = \Phi\left(z_{\alpha/2} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = P\left(z' < z_{\alpha} \right)
+                 = \Phi\left(z_{\alpha} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
     $$
 
 === "右单侧检验"
 
     $$
-    \text{Power} = P\left(z' > z_{1-\alpha/2} \right)
-                 = 1 - \Phi\left(z_{1-\alpha/2} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = P\left(z' > z_{1-\alpha} \right)
+                 = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0}{\sqrt{p(1-p)/n}}\right)
     $$
 
 ??? note "单侧检验样本量公式推导"
@@ -169,13 +169,13 @@ $$
     根据标准正态分布分位数的定义：
 
     $$
-    z_{1-\alpha/2} \pm \frac{p-p_0}{\sqrt{p(1-p)/n}} = z_{\beta}
+    z_{1-\alpha} \pm \frac{p-p_0}{\sqrt{p(1-p)/n}} = z_{\beta}
     $$
 
     可解出：
 
     $$
-    n = \frac{\left(z_{1-\alpha/2}+z_{1-\beta}\right)^2 p(1-p)}{\left(p-p_0\right)^2}
+    n = \frac{\left(z_{1-\alpha}+z_{1-\beta}\right)^2 p(1-p)}{\left(p-p_0\right)^2}
     $$
 
 ## _z-test using s(phat) with continuity correction_ {#z-test-phat-cc}
@@ -214,13 +214,13 @@ $$
 === "左单侧检验"
 
     $$
-    \text{Power} = P\left(z' < z_{\alpha/2} \right)
-                 = \Phi\left(z_{\alpha/2} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = P\left(z' < z_{\alpha} \right)
+                 = \Phi\left(z_{\alpha} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
     $$
 
 === "右单侧检验"
 
     $$
-    \text{Power} = P\left(z' > z_{1-\alpha/2} \right)
-                 = 1 - \Phi\left(z_{1-\alpha/2} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = P\left(z' > z_{1-\alpha} \right)
+                 = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0+c}{\sqrt{p(1-p)/n}}\right)
     $$


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Optimized documentation for proportion single inequality tests

- Restructured sections with clearer hypothesis statements

- Simplified and standardized power formulas across test variants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs["Proportion Single Inequality Docs"] --> intro["Notation & Hypotheses"]
  docs --> zp0["z-test using s(p0)"]
  docs --> zp0cc["z-test using s(p0) with CC"]
  docs --> zphat["z-test using s(phat)"]
  docs --> zphatcc["z-test using s(phat) with CC"]
  zp0 --> zp0power["Power Formulas"]
  zp0cc --> zp0ccpower["Power Formulas"]
  zphat --> zphatpower["Power Formulas"]
  zphatcc --> zphatccpower["Power Formulas"]
  zp0 --> zp0ss["Sample Size Derivation"]
  zphat --> zphatss["Sample Size Derivation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inequality.md</strong><dd><code>Restructured and simplified documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/algorithms/proportion/single/inequality.md

<ul><li>Restructured document with separate sections for each test variant<br> <li> Added clear notation and hypothesis statements for two-sided and <br>one-sided tests<br> <li> Simplified and unified power formulas across test types<br> <li> Added collapsible sample size derivation notes</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/465/files#diff-cc7092ba338b8e7d986cb0b8a727011edb7d9390dc7e37dde9efc8cb5480873e">+83/-353</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

