### PR TITLE
docs(algo): optimize docs of `proportion.single.noninferiority`

### DIFF
--- a/docs/algorithms/proportion/single/noninferiority.md
+++ b/docs/algorithms/proportion/single/noninferiority.md
@@ -1,5 +1,7 @@
 # 单样本率非劣效检验
 
+样本率用 $\hat{p}$ 表示，总体率用 $p$ 表示，非劣界值用 $\delta$ 表示。
+
 对于高优指标（$\delta < 0$），统计学假设如下：
 
 $$
@@ -18,131 +20,108 @@ H_1 &: p - p_0 \lt \delta
 \end{align}
 $$
 
-$\delta$ 为非劣效界值，样本比例用 $\hat{p}$ 表示。
-
-$$
-\operatorname{E}(\hat{p}) = p
-$$
-
 以下推导过程在边界条件 $p - p_0 = \delta$ 下进行。
 
+## _z-test using s(p0)_ {#z-test-p0}
 
-## Z-test using S(P0) {#z-test-p0}
-
-在 $H_0$ 成立时，使用 $p_0$ 计算样本比例 $\hat{p}$ 的方差：
-
-$$
-\operatorname{Var}(\hat{p}) = \frac{(p_0+\delta)(1-p_0-\delta)}{n}
-$$
-
-构建 $z$ 统计量：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
 z = \frac{\hat{p}-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'$ 统计量：
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
 
 $$
-z' = \frac{\hat{p}-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}} \sim N\left(\frac{p-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}, \frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}\right)
+z' = \frac{\hat{p}-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}} \sim N\left(\frac{p-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}, \frac{p(1-p)}{(p_0+\delta)(1-p_0-\delta)}\right)
 $$
 
-=== "$\delta < 0$"
+=== "高优指标"
 
     $$
-    \begin{aligned}
+    \begin{align}
         \text{Power}
     & = \operatorname{Pr}(z' > z_{1-\alpha}) \\
-    & = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}\right) \\
-    & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)/n} - (p-p_0-\delta)}{\sqrt{p(1-p)/n}}\right) \\
+    & = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)}}{\sqrt{(p_0+\delta)(1-p_0-\delta)}}}\right) \\
     & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} - (p-p_0-\delta)\sqrt{n}}{\sqrt{p(1-p)}}\right)
-    \end{aligned}
+    \end{align}
     $$
 
-=== "$\delta > 0$"
+=== "低优指标"
 
     $$
-    \begin{aligned}
+    \begin{align}
         \text{Power}
     & = \operatorname{Pr}(z' < z_{\alpha}) \\
-    & = \Phi\left(\frac{z_{\alpha} - \frac{p-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}\right) \\
-    & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)/n} + (p-p_0-\delta)}{\sqrt{p(1-p)/n}}\right) \\
+    & = \Phi\left(\frac{z_{\alpha} - \frac{p-p_0-\delta}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)}}{\sqrt{(p_0+\delta)(1-p_0-\delta)}}}\right) \\
     & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} + (p-p_0-\delta)\sqrt{n}}{\sqrt{p(1-p)}}\right)
-    \end{aligned}
+    \end{align}
     $$
 
-根据标准正态分布分位数的定义：
+??? note "样本量公式推导"
 
-$$
-\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} \pm (p-p_0-\delta)\sqrt{n}}{\sqrt{p(1-p)}} = z_{\beta}
-$$
+    根据标准正态分布分位数的定义：
 
-可解出：
+    $$
+    \frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} \pm (p-p_0-\delta)\sqrt{n}}{\sqrt{p(1-p)}} = z_{\beta}
+    $$
 
-$$
-n = \frac{\left[z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} + z_{1-\beta}\sqrt{p(1-p)}\right]^2}{\left(p-p_0-\delta\right)^2}
-$$
+    可解出：
 
+    $$
+    n = \frac{\left[z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} + z_{1-\beta}\sqrt{p(1-p)}\right]^2}{\left(p-p_0-\delta\right)^2}
+    $$
 
-## Z-test using S(P0) 连续性校正 {#z-test-p0-cc}
+## _z-test using s(p0) with continuity correction_ {#z-test-p0-cc}
 
-在 [Z-test using S(P0)](#z-test-p0) 的基础上加入校正项 $c$：
+在 [_z-test using s(p0)_](#z-test-p0) 的基础上加入校正项 $c$：
 
 $$
 c =
 \begin{cases}
 - \frac{1}{2n} & , \text{if } p \gt p_0 + \delta \\
   \frac{1}{2n} & , \text{if } p \lt p_0 + \delta \\
-  0            & , \text{if } \left| p - p_0 - \delta \right| \lt \frac{1}{2n}
+  0            & , \text{if } \left| p - p_0 - \delta \right| \leqslant \frac{1}{2n}
 \end{cases}
 $$
 
-在 $H_0$ 成立时，构建 $z$ 统计量：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
 z = \frac{\hat{p}-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'$ 统计量：
+在 $H_1$ 成立时，可构建 $z'$ 统计量：
 
 $$
-z' = \frac{\hat{p}-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}} \sim N\left(\frac{p-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}, \frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}\right)
+z' = \frac{\hat{p}-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}} \sim N\left(\frac{p-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}, \frac{p(1-p)}{(p_0+\delta)(1-p_0-\delta)}\right)
 $$
 
-=== "$\delta < 0$"
+=== "高优指标"
 
     $$
-    \begin{aligned}
+    \begin{align}
         \text{Power}
     & = \operatorname{Pr}(z' > z_{1-\alpha}) \\
-    & = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}\right) \\
-    & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)/n} - (p-p_0-\delta+c)}{\sqrt{p(1-p)/n}}\right) \\
+    & = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)}}{\sqrt{(p_0+\delta)(1-p_0-\delta)}}}\right) \\
     & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} - (p-p_0-\delta+c)\sqrt{n}}{\sqrt{p(1-p)}}\right)
-    \end{aligned}
+    \end{align}
     $$
 
-=== "$\delta > 0$"
+=== "低优指标"
 
     $$
-    \begin{aligned}
+    \begin{align}
         \text{Power}
     & = \operatorname{Pr}(z' < z_{\alpha}) \\
-    & = \Phi\left(\frac{z_{\alpha} - \frac{p-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}\right) \\
-    & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)/n} + (p-p_0-\delta+c)}{\sqrt{p(1-p)/n}}\right) \\
+    & = \Phi\left(\frac{z_{\alpha} - \frac{p-p_0-\delta+c}{\sqrt{(p_0+\delta)(1-p_0-\delta)/n}}}{\frac{\sqrt{p(1-p)}}{\sqrt{(p_0+\delta)(1-p_0-\delta)}}}\right) \\
     & = 1 - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta)(1-p_0-\delta)} + (p-p_0-\delta+c)\sqrt{n}}{\sqrt{p(1-p)}}\right)
-    \end{aligned}
+    \end{align}
     $$
 
+## _z-test using s(phat)_ {#z-test-phat}
 
-## Z-test using S(Phat) {#z-test-phat}
-
-在 $H_0$ 成立时，使用 $p$ 计算样本比例 $\hat{p}$ 的方差：
-
-$$
-\operatorname{Var}(\hat{p}) = \frac{p(1-p)}{n}
-$$
-
-构建 $z$ 统计量：
+在 $H_0$ 成立时，可构建 $z$ 统计量：
 
 $$
 z = \frac{\hat{p}-p_0-\delta}{\sqrt{p(1-p)/n}} \sim N(0, 1)
@@ -154,47 +133,42 @@ $$
 z' = \frac{\hat{p}-p_0-\delta}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}, 1\right)
 $$
 
-=== "$\delta < 0$"
+=== "高优指标"
 
     $$
-    \text{Power}
-    = \operatorname{Pr}(z' > z_{1-\alpha})
-    = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = \operatorname{Pr}(z' > z_{1-\alpha}) = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}\right)
     $$
 
-=== "$\delta > 0$"
+=== "低优指标"
 
     $$
-    \text{Power}
-    = \operatorname{Pr}(z' < z_{\alpha})
-    = \Phi\left(z_{\alpha} - \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}\right)
-    = 1 - \Phi\left(z_{1-\alpha} + \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = \operatorname{Pr}(z' < z_{\alpha}) = \Phi\left(z_{\alpha} - \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}\right) = 1 - \Phi\left(z_{1-\alpha} + \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}}\right)
     $$
 
+??? note "样本量公式推导"
 
-根据标准正态分布分位数的定义：
+    根据标准正态分布分位数的定义：
 
-$$
-z_{1-\alpha} \pm \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}} = z_{\beta}
-$$
+    $$
+    z_{1-\alpha} \pm \frac{p-p_0-\delta}{\sqrt{p(1-p)/n}} = z_{\beta}
+    $$
 
-可解出：
+    可解出：
 
-$$
-n = \frac{\left(z_{1-\alpha}+z_{1-\beta}\right)^2 p(1-p)}{\left(p-p_0-\delta\right)^2}
-$$
+    $$
+    n = \frac{\left(z_{1-\alpha}+z_{1-\beta}\right)^2 p(1-p)}{\left(p-p_0-\delta\right)^2}
+    $$
 
+## _z-test using s(phat) with continuity correction_ {#z-test-phat-cc}
 
-## Z-test using S(Phat) 连续性校正 {#z-test-phat-cc}
-
-在 [Z-test using S(Phat)](#z-test-phat) 的基础上加入校正项 $c$：
+在 [_z-test using s(phat)_](#z-test-phat) 的基础上加入校正项 $c$：
 
 $$
 c =
 \begin{cases}
 - \frac{1}{2n} & , \text{if } p \gt p_0 + \delta \\
   \frac{1}{2n} & , \text{if } p \lt p_0 + \delta \\
-  0            & , \text{if } \left| p - p_0 - \delta \right| \lt \frac{1}{2n}
+  0            & , \text{if } \left| p - p_0 - \delta \right| \leqslant \frac{1}{2n}
 \end{cases}
 $$
 
@@ -210,19 +184,14 @@ $$
 z' = \frac{\hat{p}-p_0-\delta+c}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}, 1\right)
 $$
 
-=== "$\delta < 0$"
+=== "高优指标"
 
     $$
-    \text{Power}
-    = \operatorname{Pr}(z' > z_{1-\alpha})
-    = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = \operatorname{Pr}(z' > z_{1-\alpha}) = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}\right)
     $$
 
-=== "$\delta > 0$"
+=== "低优指标"
 
     $$
-    \text{Power}
-    = \operatorname{Pr}(z' < z_{\alpha})
-    = \Phi\left(z_{\alpha} - \frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}\right)
-    = 1 - \Phi\left(z_{1-\alpha} + \frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}\right)
+    \text{Power} = \operatorname{Pr}(z' < z_{\alpha}) = \Phi\left(z_{\alpha} - \frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}\right) = 1 - \Phi\left(z_{1-\alpha} + \frac{p-p_0-\delta+c}{\sqrt{p(1-p)/n}}\right)
     $$


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added notation for sample rate, population rate, and non-inferiority margin.

- Restructured headings and improved terminology (e.g., "高优指标" / "低优指标").

- Moved sample size derivations into collapsible note sections.

- Simplified power formula denominators and fixed continuity correction condition.

- Refined equation formatting and alignment for readability.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>noninferiority.md</strong><dd><code>Optimized doc structure and formula clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/algorithms/proportion/single/noninferiority.md

<ul><li>Added initial notation definition for sample rate, population rate, <br>and non-inferiority margin.<br> <li> Updated section titles to a consistent mixed Chinese/English format <br>(e.g., "_z-test using s(p0)_").<br> <li> Replaced generic δ<0/δ>0 tabs with "高优指标" and "低优指标" labels.<br> <li> Simplified power formula fractions and moved sample size derivations <br>into collapsible note sections.<br> <li> Changed continuity correction condition from strict inequality to <br>non-strict inequality.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/468/files#diff-3cb1d7d12eb296212aa94513f9f047fecd51dfcdb1d6d97b68194f974fbf7a77">+59/-90</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

