### PR TITLE
refactor(proportion.single.noninferiority): optimize the algorithm and docstring

### DIFF
--- a/src/pystatpower/proportion/single/_power.py
+++ b/src/pystatpower/proportion/single/_power.py
@@ -1,0 +1,145 @@
+from math import sqrt
+from typing import Literal
+
+from scipy.stats import norm
+
+
+def _power_p0(
+    proportion: float,
+    null_proportion: float,
+    margin: float,
+    size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the statistical power for one proportion test, using p0 to calculate the variance."""
+
+    proportion_threshold = null_proportion + margin
+    h1_z_mean = (proportion - proportion_threshold) / sqrt(proportion_threshold * (1 - proportion_threshold) / size)
+    h1_z_std = sqrt(proportion * (1 - proportion) / (proportion_threshold * (1 - proportion_threshold)))
+    match alternative:
+        case "two-sided":
+            power = (
+                1
+                - norm.cdf((norm.ppf(1 - alpha / 2) - h1_z_mean) / h1_z_std)
+                + norm.cdf((norm.ppf(alpha / 2) - h1_z_mean) / h1_z_std)
+            )
+        case "greater":
+            power = 1 - norm.cdf((norm.ppf(1 - alpha) - h1_z_mean) / h1_z_std)
+        case "less":
+            power = norm.cdf((norm.ppf(alpha) - h1_z_mean) / h1_z_std)
+    return float(power)
+
+
+def _power_p0_cc(
+    proportion: float,
+    null_proportion: float,
+    margin: float,
+    size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the statistical power for one proportion test, using p0 with continuity correction to calculate the variance."""
+
+    proportion_threshold = null_proportion + margin
+
+    if abs(proportion - proportion_threshold) <= 1 / (2 * size):
+        c = 0
+    elif proportion > proportion_threshold:
+        c = -1 / (2 * size)
+    else:  # proportion < proportion_threshold
+        c = 1 / (2 * size)
+
+    h1_z_mean = (proportion - proportion_threshold + c) / sqrt(proportion_threshold * (1 - proportion_threshold) / size)
+    h1_z_std = sqrt(proportion * (1 - proportion) / (proportion_threshold * (1 - proportion_threshold)))
+    match alternative:
+        case "two-sided":
+            power = (
+                1
+                - norm.cdf((norm.ppf(1 - alpha / 2) - h1_z_mean) / h1_z_std)
+                + norm.cdf((norm.ppf(alpha / 2) - h1_z_mean) / h1_z_std)
+            )
+        case "greater":
+            power = 1 - norm.cdf((norm.ppf(1 - alpha) - h1_z_mean) / h1_z_std)
+        case "less":
+            power = norm.cdf((norm.ppf(alpha) - h1_z_mean) / h1_z_std)
+    return float(power)
+
+
+def _power_phat(
+    proportion: float,
+    null_proportion: float,
+    margin: float,
+    size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the statistical power for one proportion test, using phat to calculate the variance."""
+
+    proportion_threshold = null_proportion + margin
+    h1_z_mean = (proportion - proportion_threshold) / sqrt(proportion * (1 - proportion) / size)
+    match alternative:
+        case "two-sided":
+            power = 1 - norm.cdf(norm.ppf(1 - alpha / 2) - h1_z_mean) + norm.cdf(norm.ppf(alpha / 2) - h1_z_mean)
+        case "greater":
+            power = 1 - norm.cdf(norm.ppf(1 - alpha) - h1_z_mean)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - h1_z_mean)
+
+    return float(power)
+
+
+def _power_phat_cc(
+    proportion: float,
+    null_proportion: float,
+    margin: float,
+    size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+) -> float:
+    """Calculate the statistical power for one proportion test, using phat with continuity correction to calculate the variance."""
+
+    proportion_threshold = null_proportion + margin
+
+    if abs(proportion - proportion_threshold) <= 1 / (2 * size):
+        c = 0
+    elif proportion > proportion_threshold:
+        c = -1 / (2 * size)
+    else:  # proportion < proportion_threshold
+        c = 1 / (2 * size)
+
+    h1_z_mean = (proportion - proportion_threshold + c) / sqrt(proportion * (1 - proportion) / size)
+    match alternative:
+        case "two-sided":
+            power = 1 - norm.cdf(norm.ppf(1 - alpha / 2) - h1_z_mean) + norm.cdf(norm.ppf(alpha / 2) - h1_z_mean)
+        case "greater":
+            power = 1 - norm.cdf(norm.ppf(1 - alpha) - h1_z_mean)
+        case "less":
+            power = norm.cdf(norm.ppf(alpha) - h1_z_mean)
+
+    return float(power)
+
+
+def _power(
+    proportion: float,
+    null_proportion: float,
+    margin: float,
+    size: float,
+    alternative: Literal["two-sided", "greater", "less"],
+    alpha: float,
+    method: Literal["z-p0", "z-phat"],
+    continuity_correction: bool,
+) -> float:
+    """Calculate the statistical power for one proportion test."""
+
+    match method:
+        case "z-p0":
+            if continuity_correction:
+                return _power_p0_cc(proportion, null_proportion, margin, size, alternative, alpha)
+            else:
+                return _power_p0(proportion, null_proportion, margin, size, alternative, alpha)
+        case "z-phat":
+            if continuity_correction:
+                return _power_phat_cc(proportion, null_proportion, margin, size, alternative, alpha)
+            else:
+                return _power_phat(proportion, null_proportion, margin, size, alternative, alpha)

--- a/src/pystatpower/proportion/single/noninferiority.py
+++ b/src/pystatpower/proportion/single/noninferiority.py
@@ -1,321 +1,136 @@
-from math import ceil, sqrt
+from math import ceil
 from typing import Literal
 
 from scipy.optimize import brentq
-from scipy.stats import norm
 
-from ..._constant import SAMPLE_SIZE_SEARCH_MAX
+from ._power import _power
 
 
-def _power_p0(
-    null_proportion: float,
-    proportion: float,
-    margin: float,
-    size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a one-sample proportion non-inferiority test, using $p_0$ to calculate variance."""
-
-    proportion_noninf = null_proportion + margin
+def _margin(margin: float, alternative: Literal["greater", "less"]) -> float:
+    """Convert margin to standard form based on alternative hypothesis"""
 
     match alternative:
         case "greater":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
-                    - (proportion - proportion_noninf) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
+            return -abs(margin)
         case "less":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
-                    + (proportion - proportion_noninf) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-
-    return float(power)
-
-
-def _power_p0_cc(
-    null_proportion: float,
-    proportion: float,
-    margin: float,
-    size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a one-sample proportion non-inferiority test with continuity correction, using $p_0$ to calculate variance."""
-
-    proportion_noninf = null_proportion + margin
-
-    if abs(proportion - proportion_noninf) < 1 / (2 * size):
-        c = 0
-    elif proportion > proportion_noninf:
-        c = -1 / (2 * size)
-    else:  # proportion < proportion_noninf
-        c = 1 / (2 * size)
-
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
-                    - (proportion - proportion_noninf + c) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-        case "less":
-            power = 1 - norm.cdf(
-                (
-                    norm.ppf(1 - alpha) * sqrt(proportion_noninf * (1 - proportion_noninf))
-                    + (proportion - proportion_noninf + c) * sqrt(size)
-                )
-                / sqrt(proportion * (1 - proportion))
-            )
-
-    return float(power)
-
-
-def _power_phat(
-    null_proportion: float,
-    proportion: float,
-    margin: float,
-    size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a one-sample proportion non-inferiority test, using $\\hat{p}$ to calculate variance."""
-
-    proportion_noninf = null_proportion + margin
-
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                - (proportion - proportion_noninf) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-        case "less":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                + (proportion - proportion_noninf) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-
-    return float(power)
-
-
-def _power_phat_cc(
-    null_proportion: float,
-    proportion: float,
-    margin: float,
-    size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-) -> float:
-    """Calculate the statistical power for a one-sample proportion non-inferiority test with continuity correction, using $\\hat{p}$ to calculate variance."""
-
-    proportion_noninf = null_proportion + margin
-
-    if abs(proportion - proportion_noninf) < 1 / (2 * size):
-        c = 0
-    elif proportion > proportion_noninf:
-        c = -1 / (2 * size)
-    else:  # proportion < proportion_noninf
-        c = 1 / (2 * size)
-
-    match alternative:
-        case "greater":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                - (proportion - proportion_noninf + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-        case "less":
-            power = 1 - norm.cdf(
-                norm.ppf(1 - alpha)
-                + (proportion - proportion_noninf + c) * sqrt(size) / sqrt(proportion * (1 - proportion))
-            )
-
-    return float(power)
-
-
-def _power(
-    null_proportion: float,
-    proportion: float,
-    margin: float,
-    size: float,
-    alternative: Literal["greater", "less"],
-    alpha: float,
-    phat: bool,
-    continuity_correction: bool,
-) -> float:
-    """Calculate the statistical power for a one-sample proportion non-inferiority test."""
-
-    match (phat, continuity_correction):
-        case (True, True):
-            power = _power_phat_cc(null_proportion, proportion, margin, size, alternative, alpha)
-        case (True, False):
-            power = _power_phat(null_proportion, proportion, margin, size, alternative, alpha)
-        case (False, True):
-            power = _power_p0_cc(null_proportion, proportion, margin, size, alternative, alpha)
-        case (False, False):
-            power = _power_p0(null_proportion, proportion, margin, size, alternative, alpha)
-
-    return power
+            return abs(margin)
 
 
 def solve_power(
     *,
-    null_proportion: float,
     proportion: float,
+    null_proportion: float,
     margin: float,
     size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
-    phat: bool = True,
-    continuity_correction: bool = False,
+    method: Literal["z-p0", "z-phat"],
+    continuity_correction: bool,
 ) -> float:
     """
-    Calculate the statistical power for a one-sample proportion non-inferiority test.
+    Calculate the statistical power for a non-inferiority test of one proportion.
 
     Args:
-        null_proportion (float):
-            Proportion under the null hypothesis ($p_0$).
-        proportion (float):
-            Proportion under the alternative hypothesis ($p$).
-        margin (float):
-            Non-inferiority margin ($\\delta$).
-        size (int):
+        proportion:
+            Proportion under the alternative hypothesis.
+        null_proportion:
+            Proportion under the null hypothesis.
+        margin:
+            The non-inferiority margin.
+
+            Regardless of whether `alternative` is specified as `'greater'` or `'less'`, you can always specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `alternative` is `'greater'`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `'less'`, the actual margin used internally is `abs(margin)`.
+        size:
             Sample size.
-        alternative (Literal["greater", "less"]):
+        alternative:
             Type of the alternative hypothesis:
 
-            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
-            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-        alpha (float, optional):
-            One-sided significance level.
-        phat (bool, optional):
-            Specify whether to use the value of $p$ to calculate the standard deviation or not.
-        continuity_correction (bool, optional):
-            Specify whether to apply Yate's continuity correction or not.
+            - If `alternative` is `'greater'`, the alternative hypothesis is $p - p_0 > \\delta \\ (\\delta < 0)$
+            - If `alternative` is `'less'`, the alternative hypothesis is $p - p_0 < \\delta \\ (\\delta > 0)$
+        alpha:
+            Significance level.
+
+            The non-inferiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
+        continuity_correction:
+            Whether to apply the continuity correction.
 
     Returns:
-        (float): The statistical power of the test.
+        float: The statistical power of the test.
     """
 
-    return _power(null_proportion, proportion, margin, size, alternative, alpha, phat, continuity_correction)
+    margin = _margin(margin, alternative)
+
+    return _power(proportion, null_proportion, margin, size, alternative, alpha, method, continuity_correction)
 
 
 def solve_size(
     *,
-    null_proportion: float,
     proportion: float,
+    null_proportion: float,
     margin: float,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    phat: bool = True,
+    method: Literal["z-p0", "z-phat"],
     continuity_correction: bool = False,
 ) -> int:
     """
-    Estimate the required sample size for a one-sample proportion non-inferiority test.
+    Estimate the required sample size for a non-inferiority test of one proportion.
 
     Args:
-        null_proportion (float):
-            Proportion under the null hypothesis ($p_0$).
-        proportion (float):
-            Proportion under the alternative hypothesis ($p$).
-        margin (float):
-            Non-inferiority margin ($\\delta$).
-        alternative (Literal["greater", "less"]):
+        proportion:
+            Proportion under the alternative hypothesis.
+        null_proportion:
+            Proportion under the null hypothesis.
+        margin:
+            The non-inferiority margin.
+
+            Regardless of whether `alternative` is specified as `'greater'` or `'less'`, you can always specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `alternative` is `'greater'`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `'less'`, the actual margin used internally is `abs(margin)`.
+        alternative:
             Type of the alternative hypothesis:
 
-            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
-            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Power of the test.
-        phat (bool, optional):
-            Specify whether to use the value of $p$ to calculate the standard deviation or not.
-        continuity_correction (bool, optional):
-            Specify whether to apply Yate's continuity correction or not.
+            - If `alternative` is `'greater'`, the alternative hypothesis is $p - p_0 > \\delta \\ (\\delta < 0)$
+            - If `alternative` is `'less'`, the alternative hypothesis is $p - p_0 < \\delta \\ (\\delta > 0)$
+        alpha:
+            Significance level.
+
+            The non-inferiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
+        continuity_correction:
+            Whether to apply the continuity correction.
 
     Returns:
-        (int): The required sample size.
+        int: The required sample size.
     """
+
+    margin = _margin(margin, alternative)
 
     def func(size: float) -> float:
         return (
-            _power(null_proportion, proportion, margin, size, alternative, alpha, phat, continuity_correction) - power
+            _power(proportion, null_proportion, margin, size, alternative, alpha, method, continuity_correction) - power
         )
 
-    return ceil(brentq(func, 0.000001, SAMPLE_SIZE_SEARCH_MAX))
-
-
-def solve_null_proportion(
-    *,
-    proportion: float,
-    margin: float,
-    size: int,
-    alternative: Literal["greater", "less"],
-    alpha: float = 0.025,
-    power: float = 0.8,
-    phat: bool = True,
-    continuity_correction: bool = False,
-) -> float:
-    """
-    Estimate the required proportion under the null hypothesis ($p_0$) for a one-sample proportion non-inferiority test.
-
-    Args:
-        proportion (float):
-            Proportion under the alternative hypothesis ($p$).
-        margin (float):
-            Non-inferiority margin ($\\delta$).
-        size (int):
-            Sample size.
-        alternative (Literal["greater", "less"]):
-            Type of the alternative hypothesis:
-
-            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
-            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Power of the test.
-        phat (bool, optional):
-            Specify whether to use the value of $p$ to calculate the standard deviation or not.
-        continuity_correction (bool, optional):
-            Specify whether to apply Yate's continuity correction or not.
-
-    Returns:
-        (float): The required proportion under the null hypothesis ($p_0$).
-
-    Notes:
-        The search interval for the null proportion ($p_0$) is constrained by the alternative proportion ($p$) and the margin ($\\delta$) to ensure the alternative hypothesis remains plausible:
-
-        $$
-        \\text{Search Interval} =
-        \\begin{cases}
-        (-\\delta, \\operatorname{min}(p-\\delta, 1)) &, \\text{if } \\delta < 0 \\\\
-        (\\operatorname{max}(p-\\delta, 0), 1-\\delta) &, \\text{if } \\delta > 0
-        \\end{cases}
-        $$
-    """
-
-    def func(null_proportion: float) -> float:
-        return (
-            _power(null_proportion, proportion, margin, size, alternative, alpha, phat, continuity_correction) - power
-        )
-
-    if margin < 0:
-        null_proportion = brentq(func, -margin, min(proportion - margin, 0.999999))
-    else:  # margin > 0
-        null_proportion = brentq(func, max(proportion - margin, 0.000001), 1 - margin)
-
-    return float(null_proportion)
+    return ceil(brentq(func, 1e-12, 1e12))
 
 
 def solve_proportion(
@@ -326,120 +141,259 @@ def solve_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    phat: bool = True,
+    method: Literal["z-p0", "z-phat"],
     continuity_correction: bool = False,
 ) -> float:
     """
-    Estimate the required proportion under the alternative hypothesis ($p$) for a one-sample proportion non-inferiority test.
+    Estimate the required proportion under the alternative hypothesis for a non-inferiority test of one proportion.
 
     Args:
-        null_proportion (float):
-            Proportion under the null hypothesis ($p_0$).
-        margin (float):
-            Non-inferiority margin ($\\delta$).
-        size (int):
+        null_proportion:
+            Proportion under the null hypothesis.
+        margin:
+            The non-inferiority margin.
+
+            Regardless of whether `alternative` is specified as `'greater'` or `'less'`, you can always specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `alternative` is `'greater'`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `'less'`, the actual margin used internally is `abs(margin)`.
+        size:
             Sample size.
-        alternative (Literal["greater", "less"]):
+        alternative:
             Type of the alternative hypothesis:
 
-            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
-            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Power of the test.
-        phat (bool, optional):
-            Specify whether to use the value of $p$ to calculate the standard deviation or not.
-        continuity_correction (bool, optional):
-            Specify whether to apply Yate's continuity correction or not.
+            - If `alternative` is `'greater'`, the alternative hypothesis is $p - p_0 > \\delta \\ (\\delta < 0)$
+            - If `alternative` is `'less'`, the alternative hypothesis is $p - p_0 < \\delta \\ (\\delta > 0)$
+        alpha:
+            Significance level.
+
+            The non-inferiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
+        continuity_correction:
+            Whether to apply the continuity correction.
 
     Returns:
-        (float): The required proportion under the alternative hypothesis ($p$).
+        float: The required proportion under the alternative hypothesis.
 
     Notes:
-        The search interval for the alternative proportion ($p$) is constrained by the null proportion ($p_0$) and the margin ($\\delta$) to ensure the alternative hypothesis remains plausible:
+        The value range of the alternative hypothesis proportion $p$ is determined by the null hypothesis proportion $p_0$ and the non-inferiority margin $\\delta$.
+
+        If $\\delta < 0$, we have:
 
         $$
-        \\text{Search Interval} =
         \\begin{cases}
-        (\\operatorname{max}(p_0+\\delta, 0), 1) &, \\text{if } \\delta < 0 \\\\
-        (0, \\operatorname{min}(p_0+\\delta, 1)) &, \\text{if } \\delta > 0
+        p > p_0 + \\delta \\\\
+        0 < p < 1
         \\end{cases}
+        \\Rightarrow \\operatorname{max}(p_0 + \\delta, 0) < p < 1
+        $$
+
+        If $\\delta > 0$, we have:
+
+        $$
+        \\begin{cases}
+        p < p_0 + \\delta \\\\
+        0 < p < 1
+        \\end{cases}
+        \\Rightarrow 0 < p_0 < \\operatorname{min}(p_0 + \\delta, 1)
         $$
     """
 
+    margin = _margin(margin, alternative)
+
     def func(proportion: float) -> float:
         return (
-            _power(null_proportion, proportion, margin, size, alternative, alpha, phat, continuity_correction) - power
+            _power(proportion, null_proportion, margin, size, alternative, alpha, method, continuity_correction) - power
         )
 
-    if margin < 0:
-        proportion = brentq(func, max(null_proportion + margin, 0.000001), 0.999999)
-    else:  # margin > 0
-        proportion = brentq(func, 0.000001, min(null_proportion + margin, 0.999999))
+    eps = 1e-12
+    match alternative:
+        case "greater":
+            return float(brentq(func, max(null_proportion + margin, 0) + eps, 1 - eps))
+        case "less":
+            return float(brentq(func, eps, min(null_proportion + margin, 1) - eps))
 
-    return float(proportion)
 
-
-def solve_margin(
+def solve_null_proportion(
     *,
-    null_proportion: float,
     proportion: float,
+    margin: float,
     size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    phat: bool = True,
+    method: Literal["z-p0", "z-phat"],
     continuity_correction: bool = False,
 ) -> float:
     """
-    Estimate the required margin ($\\delta$) for a one-sample proportion non-inferiority test.
+    Estimate the required proportion under the null hypothesis for a non-inferiority test of one proportion.
 
     Args:
-        null_proportion (float):
-            Proportion under the null hypothesis ($p_0$).
-        proportion (float):
-            Proportion under the alternative hypothesis ($p$).
-        size (int):
+        proportion:
+            Proportion under the alternative hypothesis.
+        margin:
+            The non-inferiority margin.
+
+            Regardless of whether `alternative` is specified as `'greater'` or `'less'`, you can alwanys specify this parameter to be positive or negative as you prefer.
+            Internally, the value of `margin` will be converted before actual calculation.
+
+            - If `alternative` is `'greater'`, the actual margin used internally is `-abs(margin)`.
+            - If `alternative` is `'less'`, the actual margin used internally is `abs(margin)`.
+        size:
             Sample size.
-        alternative (Literal["greater", "less"]):
+        alternative:
             Type of the alternative hypothesis:
 
-            - `'greater'`: Upper one-tailed test ($p - p_0 > \\delta$), usually used when higher proportions are better.
-            - `'less'`: Lower one-tailed test ($p - p_0 < \\delta$), usually used when higher proportions are worse.
-        alpha (float, optional):
-            One-sided significance level.
-        power (float, optional):
-            Power of the test.
-        phat (bool, optional):
-            Specify whether to use the value of $p$ to calculate the standard deviation or not.
-        continuity_correction (bool, optional):
-            Specify whether to apply Yate's continuity correction or not.
+            - If `alternative` is `'greater'`, the alternative hypothesis is $p - p_0 > \\delta \\ (\\delta < 0)$
+            - If `alternative` is `'less'`, the alternative hypothesis is $p - p_0 < \\delta \\ (\\delta > 0)$
+        alpha:
+            Significance level.
+
+            The non-inferiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
+        continuity_correction:
+            Whether to apply the continuity correction.
 
     Returns:
-        (float): The required margin ($\\delta$).
+        float: The required proportion under the null hypothesis.
 
     Notes:
-        The search interval for the margin ($\\delta$) is constrained by the null proportion ($p_0$) and the alternative proportion ($p$) to ensure the alternative hypothesis remains plausible:
+        The value range of the null hypothesis proportion $p_0$ is determined by the alternative hypothesis proportion $p$ and the non-inferiority margin $\\delta$.
+
+        If $\\delta < 0$, we have:
 
         $$
-        \\text{Search Interval} =
         \\begin{cases}
-        (-p_0, \\operatorname{min}(p-p_0, 0))  &, \\text{if } \\delta < 0 \\\\
-        (\\operatorname{max}(p-p_0, 0), 1-p_0) &, \\text{if } \\delta > 0
+        p_0 < p - \\delta \\\\
+        0 < p_0 < 1 \\\\
+        0 < p_0 + \\delta < 1
         \\end{cases}
+        \\Rightarrow -\\delta < p_0 < \\operatorname{min}(p - \\delta, 1)
+        $$
+
+        If $\\delta > 0$, we have:
+
+        $$
+        \\begin{cases}
+        p_0 > p - \\delta \\\\
+        0 < p_0 < 1 \\\\
+        0 < p_0 + \\delta < 1
+        \\end{cases}
+        \\Rightarrow \\operatorname{max}(p - \\delta, 0) < p_0 < 1 - \\delta
+        $$
+    """
+
+    margin = _margin(margin, alternative)
+
+    def func(null_proportion: float) -> float:
+        return (
+            _power(proportion, null_proportion, margin, size, alternative, alpha, method, continuity_correction) - power
+        )
+
+    eps = 1e-12
+    match alternative:
+        case "greater":
+            return float(brentq(func, -margin + eps, min(proportion - margin, 1) - eps))
+        case "less":
+            return float(brentq(func, max(proportion - margin, 1e-12) + eps, 1 - margin - eps))
+
+
+def solve_margin(
+    *,
+    proportion: float,
+    null_proportion: float,
+    size: int,
+    alternative: Literal["greater", "less"],
+    alpha: float = 0.025,
+    power: float = 0.8,
+    method: Literal["z-p0", "z-phat"],
+    continuity_correction: bool = False,
+) -> float:
+    """
+    Estimate the required margin for a non-inferiority test of one proportion.
+
+    Args:
+        proportion:
+            Proportion under the alternative hypothesis.
+        null_proportion:
+            Proportion under the null hypothesis.
+        size:
+            Sample size.
+        alternative:
+            Type of the alternative hypothesis:
+
+            - If `alternative` is `'greater'`, the alternative hypothesis is $p - p_0 > \\delta \\ (\\delta < 0)$
+            - If `alternative` is `'less'`, the alternative hypothesis is $p - p_0 < \\delta \\ (\\delta > 0)$
+        alpha:
+            Significance level.
+
+            The non-inferiority test is a one-sided test, and 0.025 is a commonly used significance level.
+        power:
+            Expected statistical power.
+
+            0.8 is a commonly used statistical power.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
+        continuity_correction:
+            Whether to apply the continuity correction.
+
+    Returns:
+        float: The required non-inferiority margin.
+
+    Notes:
+        The value range of the non-inferiority margin $\\delta$ is determined by the alternative hypothesis proportion $p$ and the null hypothesis proportion $p_0$.
+
+        If $\\delta < 0$, we have:
+
+        $$
+        \\begin{cases}
+        \\delta < p - p_0 \\\\
+        0 < p_0 + \\delta < 1 \\\\
+        \\delta < 0
+        \\end{cases}
+        \\Rightarrow -p_0 < \\delta < \\operatorname{min}(p - p_0, 0)
+        $$
+
+        If $\\delta > 0$, we have:
+
+        $$
+        \\begin{cases}
+        \\delta > p - p_0 \\\\
+        0 < p_0 + \\delta < 1 \\\\
+        \\delta > 0
+        \\end{cases}
+        \\Rightarrow \\operatorname{max}(p - p_0, 0) < \\delta < 1 - p_0
         $$
     """
 
     def func(margin: float) -> float:
         return (
-            _power(null_proportion, proportion, margin, size, alternative, alpha, phat, continuity_correction) - power
+            _power(proportion, null_proportion, margin, size, alternative, alpha, method, continuity_correction) - power
         )
 
+    eps = 1e-12
     match alternative:
         case "greater":
-            margin = brentq(func, -null_proportion, min(proportion - null_proportion, 0))
+            return float(brentq(func, -null_proportion + eps, min(proportion - null_proportion, 0) - eps))
         case "less":
-            margin = brentq(func, max(proportion - null_proportion, 0), 1 - null_proportion)
-
-    return float(margin)
+            return float(brentq(func, max(proportion - null_proportion, 0) + eps, 1 - null_proportion - eps))

--- a/tests/test_proportion/test_single/test_noninferiority.py
+++ b/tests/test_proportion/test_single/test_noninferiority.py
@@ -9,211 +9,210 @@ from pystatpower.proportion.single.noninferiority import solve_power, solve_size
 from tests.models import BaseTestCase
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TestCase(BaseTestCase):
-    null_proportion: float
     proportion: float
+    null_proportion: float
     margin: float
     size: int
     alternative: Literal["greater", "less"]
     alpha: float
     power: float
-    phat: bool
+    method: Literal["z-p0", "z-phat"]
     continuity_correction: bool
     actual_power: float
 
 
-case_group = (
-    [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.80, 563, 0.8007),
-            (0.81, 387, 0.8011),
-            (0.82, 281, 0.8010),
-            (0.83, 213, 0.8020),
-            (0.84, 166, 0.8018),
-            (0.85, 133, 0.8032),
-            (0.86, 108, 0.8020),
-            (0.87, 89, 0.8003),
-            (0.88, 75, 0.8031),
-            (0.89, 64, 0.8071),
-            (0.90, 54, 0.8010),
-            (0.91, 47, 0.8071),
-            (0.92, 41, 0.8117),
-            (0.93, 35, 0.8016),
-            (0.94, 31, 0.8108),
-            (0.95, 27, 0.8090),
-        ]
+case_group_z_p0 = [
+    # null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, method = "z-p0", continuity_correction = False
+    TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, method="z-p0", continuity_correction=False, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.80, 563, 0.8007),
+        (0.81, 387, 0.8011),
+        (0.82, 281, 0.8010),
+        (0.83, 213, 0.8020),
+        (0.84, 166, 0.8018),
+        (0.85, 133, 0.8032),
+        (0.86, 108, 0.8020),
+        (0.87, 89, 0.8003),
+        (0.88, 75, 0.8031),
+        (0.89, 64, 0.8071),
+        (0.90, 54, 0.8010),
+        (0.91, 47, 0.8071),
+        (0.92, 41, 0.8117),
+        (0.93, 35, 0.8016),
+        (0.94, 31, 0.8108),
+        (0.95, 27, 0.8090),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.65, 31, 0.8071),
-            (0.66, 34, 0.8055),
-            (0.67, 38, 0.8082),
-            (0.68, 42, 0.8055),
-            (0.69, 47, 0.8047),
-            (0.70, 53, 0.8039),
-            (0.71, 60, 0.8017),
-            (0.72, 69, 0.8013),
-            (0.73, 81, 0.8041),
-            (0.74, 95, 0.8020),
-            (0.75, 114, 0.8022),
-            (0.76, 139, 0.8012),
-            (0.77, 174, 0.8008),
-            (0.78, 225, 0.8010),
-            (0.79, 302, 0.8000),
-            (0.80, 430, 0.8002),
-        ]
+] + [
+    # null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, method = "z-p0", continuity_correction = False
+    TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, method="z-p0", continuity_correction=False, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.65, 31, 0.8071),
+        (0.66, 34, 0.8055),
+        (0.67, 38, 0.8082),
+        (0.68, 42, 0.8055),
+        (0.69, 47, 0.8047),
+        (0.70, 53, 0.8039),
+        (0.71, 60, 0.8017),
+        (0.72, 69, 0.8013),
+        (0.73, 81, 0.8041),
+        (0.74, 95, 0.8020),
+        (0.75, 114, 0.8022),
+        (0.76, 139, 0.8012),
+        (0.77, 174, 0.8008),
+        (0.78, 225, 0.8010),
+        (0.79, 302, 0.8000),
+        (0.80, 430, 0.8002),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.80, 582, 0.8001),
-            (0.81, 403, 0.8005),
-            (0.82, 295, 0.8008),
-            (0.83, 225, 0.8014),
-            (0.84, 177, 0.8019),
-            (0.85, 142, 0.8004),
-            (0.86, 117, 0.8023),
-            (0.87, 98, 0.8047),
-            (0.88, 83, 0.8062),
-            (0.89, 71, 0.8073),
-            (0.90, 61, 0.8059),
-            (0.91, 53, 0.8064),
-            (0.92, 46, 0.8023),
-            (0.93, 41, 0.8119),
-            (0.94, 36, 0.8094),
-            (0.95, 32, 0.8137),
-        ]
+]
+
+case_group_z_p0_cc = [
+    # null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, method = "z-p0", continuity_correction = True
+    TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, method="z-p0", continuity_correction=True, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.80, 582, 0.8001),
+        (0.81, 403, 0.8005),
+        (0.82, 295, 0.8008),
+        (0.83, 225, 0.8014),
+        (0.84, 177, 0.8019),
+        (0.85, 142, 0.8004),
+        (0.86, 117, 0.8023),
+        (0.87, 98, 0.8047),
+        (0.88, 83, 0.8062),
+        (0.89, 71, 0.8073),
+        (0.90, 61, 0.8059),
+        (0.91, 53, 0.8064),
+        (0.92, 46, 0.8023),
+        (0.93, 41, 0.8119),
+        (0.94, 36, 0.8094),
+        (0.95, 32, 0.8137),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.65, 36, 0.8089),
-            (0.66, 39, 0.8047),
-            (0.67, 43, 0.8050),
-            (0.68, 47, 0.8001),
-            (0.69, 53, 0.8042),
-            (0.70, 59, 0.8009),
-            (0.71, 67, 0.8019),
-            (0.72, 77, 0.8037),
-            (0.73, 89, 0.8035),
-            (0.74, 104, 0.8024),
-            (0.75, 124, 0.8028),
-            (0.76, 150, 0.8014),
-            (0.77, 186, 0.8002),
-            (0.78, 239, 0.8009),
-            (0.79, 319, 0.8007),
-            (0.80, 450, 0.8004),
-        ]
+] + [
+    # null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, method = "z-p0", continuity_correction = True
+    TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, method="z-p0", continuity_correction=True, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.65, 36, 0.8089),
+        (0.66, 39, 0.8047),
+        (0.67, 43, 0.8050),
+        (0.68, 47, 0.8001),
+        (0.69, 53, 0.8042),
+        (0.70, 59, 0.8009),
+        (0.71, 67, 0.8019),
+        (0.72, 77, 0.8037),
+        (0.73, 89, 0.8035),
+        (0.74, 104, 0.8024),
+        (0.75, 124, 0.8028),
+        (0.76, 150, 0.8014),
+        (0.77, 186, 0.8002),
+        (0.78, 239, 0.8009),
+        (0.79, 319, 0.8007),
+        (0.80, 450, 0.8004),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.80, 503, 0.8005),
-            (0.81, 336, 0.8005),
-            (0.82, 237, 0.8009),
-            (0.83, 174, 0.8022),
-            (0.84, 131, 0.8023),
-            (0.85, 101, 0.8036),
-            (0.86, 79, 0.8045),
-            (0.87, 62, 0.8022),
-            (0.88, 50, 0.8075),
-            (0.89, 40, 0.8078),
-            (0.90, 32, 0.8074),
-            (0.91, 26, 0.8135),
-            (0.92, 20, 0.8002),
-            (0.93, 16, 0.8056),
-            (0.94, 13, 0.8224),
-            (0.95, 10, 0.8269),
-        ]
+]
+
+case_group_z_phat = [
+    # null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, method = "z-phat", continuity_correction = False
+    TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, method="z-phat", continuity_correction=False, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.80, 503, 0.8005),
+        (0.81, 336, 0.8005),
+        (0.82, 237, 0.8009),
+        (0.83, 174, 0.8022),
+        (0.84, 131, 0.8023),
+        (0.85, 101, 0.8036),
+        (0.86, 79, 0.8045),
+        (0.87, 62, 0.8022),
+        (0.88, 50, 0.8075),
+        (0.89, 40, 0.8078),
+        (0.90, 32, 0.8074),
+        (0.91, 26, 0.8135),
+        (0.92, 20, 0.8002),
+        (0.93, 16, 0.8056),
+        (0.94, 13, 0.8224),
+        (0.95, 10, 0.8269),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.65, 45, 0.8031),
-            (0.66, 49, 0.8017),
-            (0.67, 54, 0.8032),
-            (0.68, 60, 0.8059),
-            (0.69, 66, 0.8025),
-            (0.70, 74, 0.8039),
-            (0.71, 83, 0.8026),
-            (0.72, 94, 0.8015),
-            (0.73, 108, 0.8021),
-            (0.74, 125, 0.8006),
-            (0.75, 148, 0.8022),
-            (0.76, 177, 0.8006),
-            (0.77, 218, 0.8015),
-            (0.78, 275, 0.8002),
-            (0.79, 362, 0.8003),
-            (0.80, 503, 0.8005),
-        ]
+] + [
+    # null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, method = "z-phat", continuity_correction = False
+    TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, method="z-phat", continuity_correction=False, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.65, 45, 0.8031),
+        (0.66, 49, 0.8017),
+        (0.67, 54, 0.8032),
+        (0.68, 60, 0.8059),
+        (0.69, 66, 0.8025),
+        (0.70, 74, 0.8039),
+        (0.71, 83, 0.8026),
+        (0.72, 94, 0.8015),
+        (0.73, 108, 0.8021),
+        (0.74, 125, 0.8006),
+        (0.75, 148, 0.8022),
+        (0.76, 177, 0.8006),
+        (0.77, 218, 0.8015),
+        (0.78, 275, 0.8002),
+        (0.79, 362, 0.8003),
+        (0.80, 503, 0.8005),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.80, 523, 0.8007),
-            (0.81, 353, 0.8012),
-            (0.82, 251, 0.8008),
-            (0.83, 186, 0.8015),
-            (0.84, 142, 0.8026),
-            (0.85, 110, 0.8006),
-            (0.86, 87, 0.8002),
-            (0.87, 70, 0.8017),
-            (0.88, 57, 0.8041),
-            (0.89, 47, 0.8091),
-            (0.90, 38, 0.8029),
-            (0.91, 32, 0.8143),
-            (0.92, 26, 0.8089),
-            (0.93, 21, 0.8010),
-            (0.94, 18, 0.8259),
-            (0.95, 14, 0.8052),
-        ]
+]
+
+case_group_z_phat_cc = [
+    # null_proportion = 0.85, proportion = 0.80 to 0.95 by 0.01, margin = -0.10, alternative = "greater", alpha = 0.025, power = 0.80, method = "z-phat", continuity_correction = True
+    TestCase(null_proportion=0.85, proportion=proportion, margin=-0.10, size=size, alternative="greater", alpha=0.025, power=0.80, method="z-phat", continuity_correction=True, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.80, 523, 0.8007),
+        (0.81, 353, 0.8012),
+        (0.82, 251, 0.8008),
+        (0.83, 186, 0.8015),
+        (0.84, 142, 0.8026),
+        (0.85, 110, 0.8006),
+        (0.86, 87, 0.8002),
+        (0.87, 70, 0.8017),
+        (0.88, 57, 0.8041),
+        (0.89, 47, 0.8091),
+        (0.90, 38, 0.8029),
+        (0.91, 32, 0.8143),
+        (0.92, 26, 0.8089),
+        (0.93, 21, 0.8010),
+        (0.94, 18, 0.8259),
+        (0.95, 14, 0.8052),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
-        for proportion, size, actual_power in [
-            (0.65, 50, 0.8042),
-            (0.66, 54, 0.8006),
-            (0.67, 59, 0.8001),
-            (0.68, 65, 0.8010),
-            (0.69, 72, 0.8018),
-            (0.70, 80, 0.8012),
-            (0.71, 90, 0.8026),
-            (0.72, 102, 0.8034),
-            (0.73, 116, 0.8014),
-            (0.74, 134, 0.8008),
-            (0.75, 158, 0.8026),
-            (0.76, 188, 0.8007),
-            (0.77, 230, 0.8009),
-            (0.78, 289, 0.8000),
-            (0.79, 379, 0.8009),
-            (0.80, 523, 0.8007),
-        ]
+] + [
+    # null_proportion = 0.75, proportion = 0.65 to 0.80 by 0.01, margin = 0.10, alternative = "less", alpha = 0.025, power = 0.80, method = "z-phat", continuity_correction = True
+    TestCase(null_proportion=0.75, proportion=proportion, margin=0.10, size=size, alternative="less", alpha=0.025, power=0.80, method="z-phat", continuity_correction=True, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.65, 50, 0.8042),
+        (0.66, 54, 0.8006),
+        (0.67, 59, 0.8001),
+        (0.68, 65, 0.8010),
+        (0.69, 72, 0.8018),
+        (0.70, 80, 0.8012),
+        (0.71, 90, 0.8026),
+        (0.72, 102, 0.8034),
+        (0.73, 116, 0.8014),
+        (0.74, 134, 0.8008),
+        (0.75, 158, 0.8026),
+        (0.76, 188, 0.8007),
+        (0.77, 230, 0.8009),
+        (0.78, 289, 0.8000),
+        (0.79, 379, 0.8009),
+        (0.80, 523, 0.8007),
     ]
-)
+]
+
+case_group = case_group_z_p0 + case_group_z_p0_cc + case_group_z_phat + case_group_z_phat_cc
 
 
 def test_size_solve_power(case: TestCase) -> None:
     assert (
         round(
             solve_power(
-                null_proportion=case.null_proportion,
                 proportion=case.proportion,
+                null_proportion=case.null_proportion,
                 margin=case.margin,
                 size=case.size,
                 alternative=case.alternative,
                 alpha=case.alpha,
-                phat=case.phat,
+                method=case.method,
                 continuity_correction=case.continuity_correction,
             ),
             4,
@@ -231,29 +230,10 @@ def test_solve_size(case: TestCase) -> None:
             alternative=case.alternative,
             alpha=case.alpha,
             power=case.power,
-            phat=case.phat,
+            method=case.method,
             continuity_correction=case.continuity_correction,
         )
         == case.size
-    )
-
-
-def test_size_solve_null_proportion(case: TestCase) -> None:
-    assert (
-        round(
-            solve_null_proportion(
-                proportion=case.proportion,
-                margin=case.margin,
-                size=case.size,
-                alternative=case.alternative,
-                alpha=case.alpha,
-                power=case.actual_power,
-                phat=case.phat,
-                continuity_correction=case.continuity_correction,
-            ),
-            2,
-        )
-        == case.null_proportion
     )
 
 
@@ -267,7 +247,7 @@ def test_size_solve_proportion(case: TestCase) -> None:
                 alternative=case.alternative,
                 alpha=case.alpha,
                 power=case.actual_power,
-                phat=case.phat,
+                method=case.method,
                 continuity_correction=case.continuity_correction,
             ),
             2,
@@ -276,17 +256,36 @@ def test_size_solve_proportion(case: TestCase) -> None:
     )
 
 
-def test_solve_margin(case: TestCase) -> None:
+def test_size_solve_null_proportion(case: TestCase) -> None:
     assert (
         round(
-            solve_margin(
-                null_proportion=case.null_proportion,
+            solve_null_proportion(
                 proportion=case.proportion,
+                margin=case.margin,
                 size=case.size,
                 alternative=case.alternative,
                 alpha=case.alpha,
                 power=case.actual_power,
-                phat=case.phat,
+                method=case.method,
+                continuity_correction=case.continuity_correction,
+            ),
+            2,
+        )
+        == case.null_proportion
+    )
+
+
+def test_solve_margin(case: TestCase) -> None:
+    assert (
+        round(
+            solve_margin(
+                proportion=case.proportion,
+                null_proportion=case.null_proportion,
+                size=case.size,
+                alternative=case.alternative,
+                alpha=case.alpha,
+                power=case.actual_power,
+                method=case.method,
                 continuity_correction=case.continuity_correction,
             ),
             2,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Extracted power calculation to a separate helper module

- Replaced `phat` parameter with method-based selection (`"z-p0"`, `"z-phat"`)

- Added margin conversion helper to unify positive/negative inputs

- Updated docstrings and function signatures for clarity

- Refactored tests to use separate case groups per method and continuity correction


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["noninferiority.py"] --> B["_power.py"]
  C["tests/test_noninferiority.py"] --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_power.py</strong><dd><code>New power calculation module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/single/_power.py

<ul><li>New module containing power calculation functions for one proportion <br>tests<br> <li> Implements four variants: <code>_power_p0</code>, <code>_power_p0_cc</code>, <code>_power_phat</code>, <br><code>_power_phat_cc</code><br> <li> Provides a unified <code>_power</code> wrapper selecting the correct variant based <br>on method and continuity correction</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/470/files#diff-f745828e604ae1e50008a5dea822ab1429a4f5b62e5142f87ed9b89465c7d892">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>noninferiority.py</strong><dd><code>Refactor noninferiority module for clarity and reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/single/noninferiority.py

<ul><li>Replaced inline power calculations with imports from <code>_power</code><br> <li> Renamed <code>phat</code> parameter to <code>method</code> (values <code>"z-p0"</code>, <code>"z-phat"</code>)<br> <li> Added <code>_margin</code> helper to convert margin sign based on alternative <br>hypothesis<br> <li> Reordered function arguments for consistency (<code>proportion</code> before <br><code>null_proportion</code>)<br> <li> Updated docstrings with detailed parameter descriptions and <br>mathematical notes<br> <li> Adjusted search interval computations for <code>solve_null_proportion</code>, <br><code>solve_proportion</code>, <code>solve_margin</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/470/files#diff-0f631e564e15ef88a2e51acf84a7fab4ce67cf0bba5dc33009bf2326f17b5f84">+250/-296</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_noninferiority.py</strong><dd><code>Update tests for refactored API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_proportion/test_single/test_noninferiority.py

<ul><li>Updated <code>TestCase</code> dataclass to use <code>kw_only=True</code><br> <li> Replaced <code>phat</code> field with <code>method</code> field (using <code>"z-p0"</code> and <code>"z-phat"</code>)<br> <li> Split single case group into four separate groups for each method and <br>continuity correction combination<br> <li> Adapted test functions to new parameter names and argument order</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/470/files#diff-28bee4cc9f2b9d3a715e0402b34dde5d830bcc7581953e9691db6cbae9e84229">+187/-188</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

