### PR TITLE
docs: update mkdocstrings config

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -146,27 +146,40 @@ inventories = [
 paths = ["src"]
 
 [project.plugins.mkdocstrings.handlers.python.options]
+# General
 backlinks = "tree"
-docstring_options.ignore_init_summary = true
-docstring_style = "google"
-docstring_section_style = "table"
-filters = ["!^_"]
-inherited_members = true
-heading_level = 1
-merge_init_into_class = true
-parameter_headings = false
-separate_signature = true
 show_source = false
-relative_crossrefs = true
-scoped_crossrefs = true
+
+# Headings
+heading_level = 1
+parameter_headings = false
 show_root_heading = true
 show_root_toc_entry = false
 show_root_full_path = true
-show_signature_annotations = true
+show_root_members_full_path = false
 show_symbol_type_heading = true
 show_symbol_type_toc = true
-signature_crossrefs = true
+
+# Members
+inherited_members = true
 members_order = "source"
+filters = ["!^_"]
+group_by_category = true
+
+# Docstrings
+docstring_style = "google"
+docstring_options.ignore_init_summary = true
+docstring_section_style = "spacy"
+merge_init_into_class = true
+relative_crossrefs = true
+scoped_crossrefs = true
+
+# Signatures
+line_length = 120
+show_signature = true
+show_signature_annotations = true
+separate_signature = true
+signature_crossrefs = true
 
 [project.plugins.mkdocstrings.handlers.python.options.summary]
 attributes = false


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Reorganized mkdocstrings options into sections

- Added new fields: show_root_members_full_path, group_by_category, line_length, show_signature

- Changed docstring_section_style to "spacy"

- Enabled show_signature and adjusted related settings


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zensical.toml</strong><dd><code>Reorganized and expanded mkdocstrings options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

zensical.toml

<ul><li>Restructured existing options under new section headers (General, <br>Headings, Members, Docstrings, Signatures)<br> <li> Added new options: show_root_members_full_path, group_by_category, <br>line_length, show_signature<br> <li> Changed docstring_section_style from "table" to "spacy"<br> <li> Removed old settings like show_source and merged others</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/509/files#diff-c785042929d7b216744f869cd6ace6657b73aaf6a5f041da1d096c2b6e34ff04">+25/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

