### PR TITLE
refactor(spe): remove redundant functions and optimize docs

### DIFF
--- a/docs/algorithms/proportion/single/equivalence.md
+++ b/docs/algorithms/proportion/single/equivalence.md
@@ -1,57 +1,38 @@
 # 单样本率等效性检验
 
+样本率用 $\hat{p}$ 表示，总体率用 $p$ 表示，下等效界值用 $\delta_1$ 表示，上等效界值用 $\delta_2$ 表示，$\delta_1 < 0$，$\delta_2 > 0$。
+
 $$
 \begin{align}
-H_{01} &: p - p_0 \leqslant \delta_1 \text{ 或 } H_{02}: p - p_0 \geqslant \delta_2 \\
+H_{01} &: p - p_0 \leqslant \delta_1 \;\text{或}\; H_{02}: p - p_0 \geqslant \delta_2 \\
 H_1 \  &: \delta_1 < p - p_0 < \delta_2
 \end{align}
 $$
 
-$\delta_1$ 和 $\delta_2$ 为等效性界值，$\delta_1 < 0$，$\delta_2 > 0$，样本比例用 $\hat{p}$ 表示。
-
-$$
-\operatorname{E}(\hat{p}) = p
-$$
-
 以下推导过程在边界条件 $p - p_0 = \delta_1$ 和 $p - p_0 = \delta_2$ 下进行。
 
+## _Z-Test Using S(P0)_ {#z-test-p0}
 
-## Z-test using S(P0) {#z-test-p0}
-
-在 $H_{01}$ 成立时，使用 $p_0$ 计算样本比例 $\hat{p}$ 的方差：
-
-$$
-\operatorname{Var}(\hat{p}) = \frac{(p_0+\delta_1)(1-p_0-\delta_1)}{n}
-$$
-
-构建 $z_1$ 统计量：
+在 $H_{01}$ 成立时，可构建 $z_1$ 统计量：
 
 $$
 z_1 = \frac{\hat{p}-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_1$ 统计量：
-
-$$
-z'_1 = \frac{\hat{p}-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}} \sim N\left(\frac{p-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}, \frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}\right)
-$$
-
-在 $H_{02}$ 成立时，使用 $p_0$ 计算样本比例 $\hat{p}$ 的方差：
-
-$$
-\operatorname{Var}(\hat{p}) = \frac{(p_0+\delta_2)(1-p_0-\delta_2)}{n}
-$$
-
-构建 $z_2$ 统计量：
+在 $H_{02}$ 成立时，可构建 $z_2$ 统计量：
 
 $$
 z_2 = \frac{\hat{p}-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_2$ 统计量：
+在 $H_1$ 成立时，可构建 $z'_1$ 和 $z'_2$ 统计量：
 
 $$
-z'_2 = \frac{\hat{p}-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}} \sim N\left(\frac{p-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}, \frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}\right)
+z'_1 = \frac{\hat{p}-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}} \sim N\left(\frac{p-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}, \frac{p(1-p)}{(p_0+\delta_1)(1-p_0-\delta_1)}\right)
+$$
+
+$$
+z'_2 = \frac{\hat{p}-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}} \sim N\left(\frac{p-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}, \frac{p(1-p)}{(p_0+\delta_2)(1-p_0-\delta_2)}\right)
 $$
 
 计算检验效能：
@@ -59,30 +40,21 @@ $$
 $$
 \begin{align}
     \text{Power}
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - 1 \\
-& = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}}\right)
-      + \Phi\left(\frac{-z_{1-\alpha} - \frac{p-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}}\right)
-      - 1 \\
+& = P(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < z_{\alpha}) \\
+& = P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - P(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < z_{\alpha}) \\
+& \approx P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - 1 \\
+& = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}}{\sqrt{\frac{p(1-p)}{(p_0+\delta_1)(1-p_0-\delta_1)}}}\right)
+      + \Phi\left(\frac{z_{\alpha} - \frac{p-p_0-\delta_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}}{\sqrt{\frac{p(1-p)}{(p_0+\delta_2)(1-p_0-\delta_2)}}}\right) - 1 \\
 & = \begin{aligned}[t]
-    1 & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n} - (p-p_0-\delta_1)}{\sqrt{p(1-p)/n}}\right) + \\
-    1 & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n} + (p-p_0-\delta_2)}{\sqrt{p(1-p)/n}}\right) - 1
-    \end{aligned} \\
-& = \begin{aligned}[t]
-    1 & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)} - (p-p_0-\delta_1)\sqrt{n}}{\sqrt{p(1-p)}}\right) \\
-      & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)} + (p-p_0-\delta_2)\sqrt{n}}{\sqrt{p(1-p)}}\right)
+    & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n} - (p-p_0-\delta_1)}{\sqrt{p(1-p)/n}}\right) \\
+    & + \Phi\left(\frac{z_{\alpha}\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n} - (p-p_0-\delta_2)}{\sqrt{p(1-p)/n}}\right)
     \end{aligned}
 \end{align}
 $$
 
-??? note "$\operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < -z_{1-\alpha}) = 1$ 的证明"
-    略。
+## _Z-Test Using S(P0) with Continuity Correction_ {#z-test-p0-cc}
 
-
-## Z-test using S(P0) 连续性校正 {#z-test-p0-cc}
-
-在 [Z-test using S(P0)](#z-test-p0) 的基础上加入校正项 $c_1$ 和 $c_2$：
+在 [_Z-Test Using S(P0)_](#z-test-p0) 的基础上加入校正项 $c_1$ 和 $c_2$：
 
 $$
 c_1 =
@@ -102,28 +74,26 @@ c_2 =
 \end{cases}
 $$
 
-在 $H_{01}$ 成立时，构建 $z_1$ 统计量：
+在 $H_{01}$ 成立时，可构建 $z_1$ 统计量：
 
 $$
 z_1 = \frac{\hat{p}-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_1$ 统计量：
-
-$$
-z'_1 = \frac{\hat{p}-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}} \sim N\left(\frac{p-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}, \frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}\right)
-$$
-
-在 $H_{02}$ 成立时，构建 $z_2$ 统计量：
+在 $H_{02}$ 成立时，可构建 $z_2$ 统计量：
 
 $$
 z_2 = \frac{\hat{p}-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_2$ 统计量：
+在 $H_1$ 成立时，可构建 $z'_1$ 和 $z'_2$ 统计量：
 
 $$
-z'_2 = \frac{\hat{p}-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}} \sim N\left(\frac{p-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}, \frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}\right)
+z'_1 = \frac{\hat{p}-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}} \sim N\left(\frac{p-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}, \frac{p(1-p)}{(p_0+\delta_1)(1-p_0-\delta_1)}\right)
+$$
+
+$$
+z'_2 = \frac{\hat{p}-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}} \sim N\left(\frac{p-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}, \frac{p(1-p)}{(p_0+\delta_2)(1-p_0-\delta_2)}\right)
 $$
 
 计算检验效能：
@@ -131,58 +101,37 @@ $$
 $$
 \begin{align}
     \text{Power}
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - 1 \\
-& = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}}\right)
-      + \Phi\left(\frac{-z_{1-\alpha} - \frac{p-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}}{\frac{\sqrt{p(1-p)/n}}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}}\right)
-      - 1 \\
+& = P(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < z_{\alpha}) \\
+& = P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - P(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < z_{\alpha}) \\
+& \approx P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - 1 \\
+& = 1 - \Phi\left(\frac{z_{1-\alpha} - \frac{p-p_0-\delta_1+c_1}{\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n}}}{\sqrt{\frac{p(1-p)}{(p_0+\delta_1)(1-p_0-\delta_1)}}}\right)
+      + \Phi\left(\frac{z_{\alpha} - \frac{p-p_0-\delta_2+c_2}{\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n}}}{\sqrt{\frac{p(1-p)}{(p_0+\delta_2)(1-p_0-\delta_2)}}}\right) - 1 \\
 & = \begin{aligned}[t]
-    1 & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n} - (p-p_0-\delta_1+c_1)}{\sqrt{p(1-p)/n}}\right) + \\
-    1 & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n} + (p-p_0-\delta_2+c_2)}{\sqrt{p(1-p)/n}}\right) - 1
-    \end{aligned} \\
-& = \begin{aligned}[t]
-    1 & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)} - (p-p_0-\delta_1+c_1)\sqrt{n}}{\sqrt{p(1-p)}}\right) \\
-      & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)} + (p-p_0-\delta_2+c_2)\sqrt{n}}{\sqrt{p(1-p)}}\right)
+    & - \Phi\left(\frac{z_{1-\alpha}\sqrt{(p_0+\delta_1)(1-p_0-\delta_1)/n} - (p-p_0-\delta_1+c_1)}{\sqrt{p(1-p)/n}}\right) \\
+    & + \Phi\left(\frac{z_{\alpha}\sqrt{(p_0+\delta_2)(1-p_0-\delta_2)/n} - (p-p_0-\delta_2+c_2)}{\sqrt{p(1-p)/n}}\right)
     \end{aligned}
 \end{align}
 $$
 
+## _Z-Test Using S(Phat)_ {#z-test-phat}
 
-## Z-test using S(Phat) {#z-test-phat}
-
-
-在 $H_{01}$ 成立时，使用 $p$ 计算样本比例 $\hat{p}$ 的方差：
-
-$$
-\operatorname{Var}(\hat{p}) = \frac{p(1-p)}{n}
-$$
-
-构建 $z_1$ 统计量：
+在 $H_{01}$ 成立时，可构建 $z_1$ 统计量：
 
 $$
 z_1 = \frac{\hat{p}-p_0-\delta_1}{\sqrt{p(1-p)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_1$ 统计量：
-
-$$
-z'_1 = \frac{\hat{p}-p_0-\delta_1}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta_1}{\sqrt{p(1-p)/n}}, 1\right)
-$$
-
-在 $H_{01}$ 成立时，使用 $p$ 计算样本比例 $\hat{p}$ 的方差：
-
-$$
-\operatorname{Var}(\hat{p}) = \frac{p(1-p)}{n}
-$$
-
-构建 $z_2$ 统计量：
+在 $H_{02}$ 成立时，可构建 $z_2$ 统计量：
 
 $$
 z_2 = \frac{\hat{p}-p_0-\delta_2}{\sqrt{p(1-p)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_2$ 统计量：
+在 $H_1$ 成立时，可构建 $z'_1$ 和 $z'_2$ 统计量：
+
+$$
+z'_1 = \frac{\hat{p}-p_0-\delta_1}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta_1}{\sqrt{p(1-p)/n}}, 1\right)
+$$
 
 $$
 z'_2 = \frac{\hat{p}-p_0-\delta_2}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta_2}{\sqrt{p(1-p)/n}}, 1\right)
@@ -193,22 +142,18 @@ $$
 $$
 \begin{align}
     \text{Power}
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - 1 \\
+& = P(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < z_{\alpha}) \\
+& = P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - P(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < z_{\alpha}) \\
+& \approx P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - 1 \\
 & = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta_1}{\sqrt{p(1-p)/n}}\right)
-      + \Phi\left(-z_{1-\alpha} - \frac{p-p_0-\delta_2}{\sqrt{p(1-p)/n}}\right)
-      - 1 \\
-& = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta_1}{\sqrt{p(1-p)/n}}\right) +
-    1 - \Phi\left(z_{1-\alpha} + \frac{p-p_0-\delta_2}{\sqrt{p(1-p)/n}}\right) - 1 \\
-& = 1 - \Phi\left(z_{1-\alpha} - \frac{(p-p_0-\delta_1)\sqrt{n}}{\sqrt{p(1-p)}}\right) - \Phi\left(z_{1-\alpha} + \frac{(p-p_0-\delta_2)\sqrt{n}}{\sqrt{p(1-p)}}\right)
+      + \Phi\left(z_{\alpha} - \frac{p-p_0-\delta_2}{\sqrt{p(1-p)/n}}\right) - 1 \\
+& = - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta_1}{\sqrt{p(1-p)/n}}\right) + \Phi\left(z_{\alpha} - \frac{p-p_0-\delta_2}{\sqrt{p(1-p)/n}}\right)
 \end{align}
 $$
 
+## _Z-Test Using S(Phat) with Continuity Correction_ {#z-test-phat-cc}
 
-## Z-test using S(Phat) 连续性校正 {#z-test-phat-cc}
-
-在 [Z-test using S(Phat)](#z-test-phat) 的基础上加入校正项 $c$：
+在 [_Z-Test Using S(Phat)_](#z-test-phat) 的基础上加入校正项 $c$：
 
 $$
 c_1 =
@@ -228,25 +173,23 @@ c_2 =
 \end{cases}
 $$
 
-在 $H_{01}$ 成立时，构建 $z_1$ 统计量：
+在 $H_{01}$ 成立时，可构建 $z_1$ 统计量：
 
 $$
 z_1 = \frac{\hat{p}-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_1$ 统计量：
-
-$$
-z'_1 = \frac{\hat{p}-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}}, 1\right)
-$$
-
-在 $H_{01}$ 成立时，构建 $z_2$ 统计量：
+在 $H_{02}$ 成立时，可构建 $z_2$ 统计量：
 
 $$
 z_2 = \frac{\hat{p}-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}} \sim N(0, 1)
 $$
 
-在 $H_1$ 成立时，构建 $z'_2$ 统计量：
+在 $H_1$ 成立时，可构建 $z'_1$ 和 $z'_2$ 统计量：
+
+$$
+z'_1 = \frac{\hat{p}-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}}, 1\right)
+$$
 
 $$
 z'_2 = \frac{\hat{p}-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}} \sim N\left(\frac{p-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}}, 1\right)
@@ -257,14 +200,15 @@ $$
 $$
 \begin{align}
     \text{Power}
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - \operatorname{Pr}(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < -z_{1-\alpha}) \\
-& = \operatorname{Pr}(z'_1 > z_{1-\alpha}) + \operatorname{Pr}(z'_2 < -z_{1-\alpha}) - 1 \\
+& = P(z'_1 > z_{1-\alpha} \ \cap \ z'_2 < z_{\alpha}) \\
+& = P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - P(z'_1 > z_{1-\alpha} \ \cup \ z'_2 < z_{\alpha}) \\
+& \approx P(z'_1 > z_{1-\alpha}) + P(z'_2 < z_{\alpha}) - 1 \\
 & = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}}\right)
-      + \Phi\left(-z_{1-\alpha} - \frac{p-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}}\right)
-      - 1 \\
-& = 1 - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}}\right) +
-    1 - \Phi\left(z_{1-\alpha} + \frac{p-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}}\right) - 1 \\
-& = 1 - \Phi\left(z_{1-\alpha} - \frac{(p-p_0-\delta_1+c_1)\sqrt{n}}{\sqrt{p(1-p)}}\right) - \Phi\left(z_{1-\alpha} + \frac{(p-p_0-\delta_2+c_2)\sqrt{n}}{\sqrt{p(1-p)}}\right)
+      + \Phi\left(z_{\alpha} - \frac{p-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}}\right) - 1 \\
+& = - \Phi\left(z_{1-\alpha} - \frac{p-p_0-\delta_1+c_1}{\sqrt{p(1-p)/n}}\right) + \Phi\left(z_{\alpha} - \frac{p-p_0-\delta_2+c_2}{\sqrt{p(1-p)/n}}\right)
 \end{align}
 $$
+
+!!! quote "参考文献"
+
+    1. Chow S C, Shao J, Wang H, et al. Sample size calculations in clinical research[M]. chapman and hall/CRC, 2017.

--- a/src/pystatpower/proportion/single/equivalence.py
+++ b/src/pystatpower/proportion/single/equivalence.py
@@ -1,248 +1,114 @@
-from math import ceil, sqrt
+from math import ceil
 from typing import Literal
 
-from scipy.optimize import OptimizeResult, brentq, minimize_scalar
-from scipy.stats import norm
+from scipy.optimize import brentq
 
-from ..._constant import SAMPLE_SIZE_SEARCH_MAX
-
-
-def _continuity_correction(proportion: float, proportion_margin: float, size: float) -> float:
-    """Calculate the value of the correction term required for continuity correction"""
-
-    if abs(proportion - proportion_margin) < 1 / (2 * size):
-        c = 0
-    elif proportion > proportion_margin:
-        c = -1 / (2 * size)
-    else:  # proportion < proportion_margin
-        c = 1 / (2 * size)
-
-    return c
-
-
-def _power_p0(
-    null_proportion: float,
-    proportion: float,
-    margin_lower: float,
-    margin_upper: float,
-    size: float,
-    alpha: float,
-) -> float:
-    """Calculate the statistical power, using $p_0$ to calculate variance."""
-
-    proportion_lower = null_proportion + margin_lower
-    proportion_upper = null_proportion + margin_upper
-
-    power = (
-        1
-        - norm.cdf(
-            (
-                norm.ppf(1 - alpha) * sqrt(proportion_lower * (1 - proportion_lower))
-                - (proportion - proportion_lower) * sqrt(size)
-            )
-            / sqrt(proportion * (1 - proportion))
-        )
-        - norm.cdf(
-            (
-                norm.ppf(1 - alpha) * sqrt(proportion_upper * (1 - proportion_upper))
-                + (proportion - proportion_upper) * sqrt(size)
-            )
-            / sqrt(proportion * (1 - proportion))
-        )
-    )
-
-    return float(power)
-
-
-def _power_p0_cc(
-    null_proportion: float,
-    proportion: float,
-    margin_lower: float,
-    margin_upper: float,
-    size: float,
-    alpha: float,
-) -> float:
-    """Calculate the statistical power, using p0 to calculate variance with continuity correction."""
-
-    proportion_lower = null_proportion + margin_lower
-    proportion_upper = null_proportion + margin_upper
-
-    c_lower = _continuity_correction(proportion, proportion_lower, size)
-    c_upper = _continuity_correction(proportion, proportion_upper, size)
-
-    power = (
-        1
-        - norm.cdf(
-            (
-                norm.ppf(1 - alpha) * sqrt(proportion_lower * (1 - proportion_lower))
-                - (proportion - proportion_lower + c_lower) * sqrt(size)
-            )
-            / sqrt(proportion * (1 - proportion))
-        )
-        - norm.cdf(
-            (
-                norm.ppf(1 - alpha) * sqrt(proportion_upper * (1 - proportion_upper))
-                + (proportion - proportion_upper + c_upper) * sqrt(size)
-            )
-            / sqrt(proportion * (1 - proportion))
-        )
-    )
-
-    return float(power)
-
-
-def _power_phat(
-    null_proportion: float,
-    proportion: float,
-    margin_lower: float,
-    margin_upper: float,
-    size: float,
-    alpha: float,
-) -> float:
-    """Calculate the statistical power, using phat to calculate variance."""
-
-    proportion_lower = null_proportion + margin_lower
-    proportion_upper = null_proportion + margin_upper
-
-    power = (
-        1
-        - norm.cdf(
-            norm.ppf(1 - alpha) - (proportion - proportion_lower) * sqrt(size) / sqrt(proportion * (1 - proportion))
-        )
-        - norm.cdf(
-            norm.ppf(1 - alpha) + (proportion - proportion_upper) * sqrt(size) / sqrt(proportion * (1 - proportion))
-        )
-    )
-
-    return float(power)
-
-
-def _power_phat_cc(
-    null_proportion: float,
-    proportion: float,
-    margin_lower: float,
-    margin_upper: float,
-    size: float,
-    alpha: float,
-) -> float:
-    """Calculate the statistical power, using phat to calculate variance with continuity correction."""
-
-    proportion_lower = null_proportion + margin_lower
-    proportion_upper = null_proportion + margin_upper
-
-    c_lower = _continuity_correction(proportion, proportion_lower, size)
-    c_upper = _continuity_correction(proportion, proportion_upper, size)
-
-    power = (
-        1
-        - norm.cdf(
-            norm.ppf(1 - alpha)
-            - (proportion - proportion_lower + c_lower) * sqrt(size) / sqrt(proportion * (1 - proportion))
-        )
-        - norm.cdf(
-            norm.ppf(1 - alpha)
-            + (proportion - proportion_upper + c_upper) * sqrt(size) / sqrt(proportion * (1 - proportion))
-        )
-    )
-
-    return float(power)
+from ._power import _power as _raw_power
 
 
 def _power(
-    null_proportion: float,
     proportion: float,
+    null_proportion: float,
     margin_lower: float,
     margin_upper: float,
     size: float,
     alpha: float,
-    phat: bool,
+    method: Literal["z-p0", "z-phat"],
     continuity_correction: bool,
 ) -> float:
     """Calculate the statistical power."""
 
-    match (phat, continuity_correction):
-        case (True, True):
-            power = _power_phat_cc(null_proportion, proportion, margin_lower, margin_upper, size, alpha)
-        case (True, False):
-            power = _power_phat(null_proportion, proportion, margin_lower, margin_upper, size, alpha)
-        case (False, True):
-            power = _power_p0_cc(null_proportion, proportion, margin_lower, margin_upper, size, alpha)
-        case (False, False):
-            power = _power_p0(null_proportion, proportion, margin_lower, margin_upper, size, alpha)
-
-    return power
+    return (
+        _raw_power(proportion, null_proportion + margin_lower, size, "greater", alpha, method, continuity_correction)
+        + _raw_power(proportion, null_proportion + margin_upper, size, "less", alpha, method, continuity_correction)
+        - 1
+    )
 
 
 def solve_power(
     *,
-    null_proportion: float,
     proportion: float,
+    null_proportion: float,
     margin_lower: float,
     margin_upper: float,
     size: int,
     alpha: float = 0.025,
-    phat: bool = True,
+    method: Literal["z-p0", "z-phat"],
     continuity_correction: bool = False,
 ) -> float:
     """
     Calculate the statistical power.
 
     Args:
-        null_proportion:
-            Proportion under the null hypothesis ($p_0$).
         proportion:
-            Proportion under the alternative hypothesis ($p$).
+            Proportion under the alternative hypothesis.
+        null_proportion:
+            Proportion under the null hypothesis.
         margin_lower:
-            Lower equivalence margin ($\\delta_1$), a negative value is required.
+            The lower equivalence margin, must be a negative value.
         margin_upper:
-            Upper equivalence margin ($\\delta_2$), a positive value is required.
+            The upper equivalence margin, must be a positive value.
         size:
             Sample size.
         alpha:
-            One-sided significance level.
-        phat:
-            Whether to use the alternative proportion $p$ to calculate the standard deviation.
+            Significance level.
+
+            The equivalence test is a two one-sided test, with a significance level of 0.025 being commonly used.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
         continuity_correction:
-            Whether to apply Yate's continuity correction.
+            Whether to apply the continuity correction.
 
     Returns:
         The statistical power of the test.
     """
 
-    return _power(null_proportion, proportion, margin_lower, margin_upper, size, alpha, phat, continuity_correction)
+    return _power(proportion, null_proportion, margin_lower, margin_upper, size, alpha, method, continuity_correction)
 
 
 def solve_size(
     *,
-    null_proportion: float,
     proportion: float,
+    null_proportion: float,
     margin_lower: float,
     margin_upper: float,
     alpha: float = 0.025,
     power: float = 0.8,
-    phat: bool = True,
+    method: Literal["z-p0", "z-phat"],
     continuity_correction: bool = False,
 ) -> int:
     """
     Estimate the required sample size.
 
     Args:
-        null_proportion:
-            Proportion under the null hypothesis ($p_0$).
         proportion:
-            Proportion under the alternative hypothesis ($p$).
+            Proportion under the alternative hypothesis.
+        null_proportion:
+            Proportion under the null hypothesis.
         margin_lower:
-            Lower equivalence margin ($\\delta_1$), a negative value is required.
+            The lower equivalence margin, must be a negative value.
         margin_upper:
-            Upper equivalence margin ($\\delta_2$), a positive value is required.
+            The upper equivalence margin, must be a positive value.
+        size:
+            Sample size.
         alpha:
-            One-sided significance level.
+            Significance level.
+
+            The equivalence test is a two one-sided test, with a significance level of 0.025 being commonly used.
         power:
-            Power of the test.
-        phat:
-            Whether to use the alternative proportion $p$ to calculate the standard deviation.
+            Expected statistical power.
+
+            0.8 is a commonly used value for statistical power.
+        method:
+            The method used to construct the test statistic.
+
+            - `'z-p0'`: Standard normal distribution (large sample approximation), using p0 to calculate the variance.
+            - `'z-phat'`: Standard normal distribution (large sample approximation), using phat to calculate the variance.
         continuity_correction:
-            Whether to apply Yate's continuity correction.
+            Whether to apply the continuity correction.
 
     Returns:
         The required sample size.
@@ -250,177 +116,8 @@ def solve_size(
 
     def func(size: float) -> float:
         return (
-            _power(null_proportion, proportion, margin_lower, margin_upper, size, alpha, phat, continuity_correction)
+            _power(proportion, null_proportion, margin_lower, margin_upper, size, alpha, method, continuity_correction)
             - power
         )
 
-    return ceil(brentq(func, 0.000001, SAMPLE_SIZE_SEARCH_MAX))
-
-
-def solve_null_proportion(
-    *,
-    proportion: float,
-    margin_lower: float,
-    margin_upper: float,
-    size: int,
-    alpha: float = 0.025,
-    power: float = 0.8,
-    phat: bool = True,
-    continuity_correction: bool = False,
-    search_direction: Literal["lower", "upper"] = "upper",
-) -> float:
-    """
-    Estimate the required proportion under the null hypothesis.
-
-    Args:
-        proportion:
-            Proportion under the alternative hypothesis.
-        margin_lower:
-            Lower equivalence margin ($\\delta_1$), a negative value is required.
-        margin_upper:
-            Upper equivalence margin ($\\delta_2$), a positive value is required.
-        size:
-            Sample size.
-        alpha:
-            One-sided significance level.
-        power:
-            Power of the test.
-        phat:
-            Whether to use the alternative proportion $p$ to calculate the standard deviation.
-        continuity_correction:
-            Whether to apply Yate's continuity correction.
-        search_direction:
-            The direction to search for the null proportion relative to the maximum power point ($p_{\\text{argmax}}$), if two valid solutions exist.
-
-            - `'lower'`: Search for $p_0$ in the interval below $p_{\\text{argmax}}$.
-            - `'upper'`: Search for $p_0$ in the interval above $p_{\\text{argmax}}$.
-
-            If $p$ itself satisfies the target power, this parameter is ignored and $p$ is returned directly.
-
-    Returns:
-        The required proportion under the null hypothesis ($p_0$).
-
-    Notes:
-        The search interval for the null proportion ($p_0$) is constrained by the alternative proportion ($p$) and
-        the equivalence margins ($\\delta_1$, $\\delta_2$) to ensure the alternative hypothesis remains plausible.
-
-        When the target power intersects the power curve at two points, the search spaces are partitioned by the maximum power point ($p_{\\text{argmax}}$):
-
-        - if `search_direction='lower'`: The interval is $(\\operatorname{max}(p-\\delta_2, -\\delta_1, 0), p_{\\text{argmax}})$
-        - if `search_direction='upper'`: The interval is $(p_{\\text{argmax}}, \\operatorname{min}(p-\\delta_1, 1-\\delta_2, 1))$
-
-        where $p_{\\text{argmax}}$ is the specific null proportion that maximizes the power function (or minimizes the negative power function).
-    """
-
-    def func(null_proportion: float) -> float:
-        return (
-            _power(null_proportion, proportion, margin_lower, margin_upper, size, alpha, phat, continuity_correction)
-            - power
-        )
-
-    f_proportion = func(proportion)
-    if abs(f_proportion) < 1e-7:
-        null_proportion = proportion
-    else:
-        lower_bound = max(proportion - margin_upper, -margin_lower, 0.000001)
-        upper_bound = min(proportion - margin_lower, 1 - margin_upper, 0.999999)
-
-        if func(lower_bound) * func(upper_bound) < 0:
-            null_proportion = brentq(func, lower_bound, upper_bound)
-        else:
-            # find the maximum value point of the power function
-            res: OptimizeResult = minimize_scalar(
-                lambda null_proportion: -func(null_proportion), bounds=(lower_bound, upper_bound)
-            )
-            if res.success:
-                null_proportion_argmin = float(res.x)
-
-            match search_direction:
-                case "lower":
-                    null_proportion = brentq(func, lower_bound, null_proportion_argmin)
-                case "upper":
-                    null_proportion = brentq(func, null_proportion_argmin, upper_bound)
-
-    return float(null_proportion)
-
-
-def solve_proportion(
-    *,
-    null_proportion: float,
-    margin_lower: float,
-    margin_upper: float,
-    size: int,
-    alpha: float = 0.025,
-    power: float = 0.8,
-    phat: bool = True,
-    continuity_correction: bool = False,
-    search_direction: Literal["lower", "upper"] = "upper",
-) -> float:
-    """
-    Estimate the required proportion under the alternative hypothesis.
-
-    Args:
-        null_proportion:
-            Proportion under the null hypothesis ($p_0$).
-        margin_lower:
-            Lower equivalence margin ($\\delta_1$), a negative value is required
-        margin_upper:
-            Upper equivalence margin ($\\delta_2$), a positive value is required.
-        size:
-            Sample size.
-        alpha:
-            One-sided significance level.
-        power:
-            Power of the test.
-        phat:
-            Whether to use the alternative proportion $p$ to calculate the standard deviation.
-        continuity_correction:
-            Whether to apply Yate's continuity correction.
-        search_direction:
-            The direction to search for the proportion relative to the maximum power point ($p_{\\text{argmax}}$), if two valid solutions exist.
-
-            - `lower`: Search for $p$ in the interval below $p_{\\text{argmax}}$.
-            - `upper`: Search for $p$ in the interval above $p_{\\text{argmax}}$.
-
-            If $p_0$ itself satisfies the target power, this parameter is ignored and $p_0$ is returned directly.
-
-    Returns:
-        The required proportion under the alternative hypothesis ($p$).
-
-    Notes:
-        The search interval for the alternative proportion ($p$) is constrained by the null proportion ($p$) and
-        the equivalence margins ($\\delta_1$, $\\delta_2$) to ensure the  alternative hypothesis remains plausible.
-
-        When the target power intersects the power curve at two points, the search spaces are partitioned by the maximum power point ($p_{\\text{argmax}}$):
-
-        - if `search_direction='lower'`: The interval is $(\\operatorname{max}(p_0+\\delta_1, 0), p_{\\text{argmax}})$
-        - if `search_direction='upper'`: The interval is $(p_{\\text{argmax}}, \\operatorname{min}(p_0+\\delta_2, 1))$
-
-        where $p_{\\text{argmax}}$ is the specific alternative proportion that maximizes the power function (or minimizes the negative power function).
-    """
-
-    def func(proportion: float) -> float:
-        return (
-            _power(null_proportion, proportion, margin_lower, margin_upper, size, alpha, phat, continuity_correction)
-            - power
-        )
-
-    f_null_proportion = func(null_proportion)
-    if abs(f_null_proportion) < 1e-7:
-        proportion = null_proportion
-    else:
-        lower_bound = max(null_proportion + margin_lower, 0.000001)
-        upper_bound = min(null_proportion + margin_upper, 0.999999)
-
-        # find the maximum value point of the power function
-        res: OptimizeResult = minimize_scalar(lambda proportion: -func(proportion), bounds=(lower_bound, upper_bound))
-        if res.success:
-            proportion_argmin = float(res.x)
-
-        match search_direction:
-            case "lower":
-                proportion = brentq(func, lower_bound, proportion_argmin)
-            case "upper":
-                proportion = brentq(func, proportion_argmin, upper_bound)
-
-    return float(proportion)
+    return ceil(brentq(func, 1e-12, 1e12))

--- a/src/pystatpower/proportion/single/equivalence.py
+++ b/src/pystatpower/proportion/single/equivalence.py
@@ -92,8 +92,6 @@ def solve_size(
             The lower equivalence margin, must be a negative value.
         margin_upper:
             The upper equivalence margin, must be a positive value.
-        size:
-            Sample size.
         alpha:
             Significance level.
 

--- a/tests/test_proportion/test_single/test_equivalence.py
+++ b/tests/test_proportion/test_single/test_equivalence.py
@@ -1,223 +1,162 @@
-# Validation Software: PASS 15
+# Validation Software: PASS 2025
 # Module: Equivalence Tests for One Proportion
 
 from dataclasses import dataclass
+from typing import Literal
 
-from pystatpower.proportion.single.equivalence import solve_power, solve_size, solve_null_proportion, solve_proportion
+from pystatpower.proportion.single.equivalence import solve_power, solve_size
 
 from tests.models import BaseTestCase
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TestCase(BaseTestCase):
-    null_proportion: float
     proportion: float
+    null_proportion: float
     margin_lower: float
     margin_upper: float
     size: int
     alpha: float
-    power: float
-    phat: bool
+    method: Literal["z-p0", "z-phat"]
     continuity_correction: bool
+    power: float
     actual_power: float
 
 
-case_group = (
-    [
-        # Regular Cases: null_proportion = 0.80, proportion = 0.71 to 0.89 by 0.01, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, phat = False, continuity_correction = False
-        TestCase(null_proportion=0.80, proportion=proportion, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, phat=False, continuity_correction=False, actual_power=actual_power)
-        for proportion, actual_power, size in [
-            (0.71, 0.800008645, 16386),
-            (0.72, 0.800020228, 4071),
-            (0.73, 0.800170764, 1798),
-            (0.74, 0.800067735, 1004),
-            (0.75, 0.800214634, 638),
-            (0.76, 0.800628722, 440),
-            (0.77, 0.801179861, 321),
-            (0.78, 0.800959648, 244),
-            (0.79, 0.800726425, 195),
-            (0.80, 0.801789107, 168),
-            (0.81, 0.801493296, 156),
-            (0.82, 0.802101987, 157),
-            (0.83, 0.801542134, 175),
-            (0.84, 0.800570668, 224),
-            (0.85, 0.800243662, 316),
-            (0.86, 0.800715517, 485),
-            (0.87, 0.800003797, 843),
-            (0.88, 0.800122869, 1856),
-            (0.89, 0.800025059, 7248),
-        ]
+case_group_z_p0 = [
+    # proportion = 0.71 to 0.89 by 0.01, null_proportion = 0.80, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, method = "z-p0", continuity_correction = False
+    TestCase(proportion=proportion, null_proportion=0.80, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, method="z-p0", continuity_correction=False, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.71, 16386, 0.800008645395320),
+        (0.72, 4071, 0.800020228237472),
+        (0.73, 1798, 0.800170764010163),
+        (0.74, 1004, 0.800067735296659),
+        (0.75, 638, 0.800214633755415),
+        (0.76, 440, 0.800628721682362),
+        (0.77, 321, 0.801179860895646),
+        (0.78, 244, 0.800959648152263),
+        (0.79, 195, 0.800726424606503),
+        (0.80, 168, 0.801789107079452),
+        (0.81, 156, 0.801493296253854),
+        (0.82, 157, 0.802101987330091),
+        (0.83, 175, 0.801542133869552),
+        (0.84, 224, 0.800570667573584),
+        (0.85, 316, 0.800243662399114),
+        (0.86, 485, 0.800715516538510),
+        (0.87, 843, 0.800003797491396),
+        (0.88, 1856, 0.800122869124067),
+        (0.89, 7248, 0.800025059163928),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.80, proportion = 0.71 to 0.89 by 0.01, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, phat = False, continuity_correction = True
-        TestCase(null_proportion=0.80, proportion=proportion, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, phat=False, continuity_correction=True, actual_power=actual_power)
-        for proportion, actual_power, size in [
-            (0.71, 0.800012300, 16486),
-            (0.72, 0.800035048, 4121),
-            (0.73, 0.800130265, 1831),
-            (0.74, 0.800128889, 1029),
-            (0.75, 0.800311804, 658),
-            (0.76, 0.800146911, 456),
-            (0.77, 0.801010771, 335),
-            (0.78, 0.800466128, 256),
-            (0.79, 0.801312828, 206),
-            (0.80, 0.802230800, 178),
-            (0.81, 0.802350624, 166),
-            (0.82, 0.800337918, 167),
-            (0.83, 0.801996006, 188),
-            (0.84, 0.800175658, 240),
-            (0.85, 0.800571559, 336),
-            (0.86, 0.800208240, 509),
-            (0.87, 0.800426339, 877),
-            (0.88, 0.800188410, 1906),
-            (0.89, 0.800042936, 7348),
-        ]
+]
+
+case_group_z_p0_cc = [
+    # proportion = 0.71 to 0.89 by 0.01, null_proportion = 0.80, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, method = "z-p0", continuity_correction = True
+    TestCase(proportion=proportion, null_proportion=0.80, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, method="z-p0", continuity_correction=True, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.71, 16486, 0.800012299780784),
+        (0.72, 4121, 0.800035047971845),
+        (0.73, 1831, 0.800130265198342),
+        (0.74, 1029, 0.800128888526456),
+        (0.75, 658, 0.800311803767697),
+        (0.76, 456, 0.800146910867358),
+        (0.77, 335, 0.801010770820005),
+        (0.78, 256, 0.800466127949615),
+        (0.79, 206, 0.801312828015927),
+        (0.80, 178, 0.802230800014678),
+        (0.81, 166, 0.802350624361241),
+        (0.82, 167, 0.800337918494614),
+        (0.83, 188, 0.801996006026150),
+        (0.84, 240, 0.800175657767678),
+        (0.85, 336, 0.800571558656332),
+        (0.86, 509, 0.800208239574793),
+        (0.87, 877, 0.800426338593650),
+        (0.88, 1906, 0.800188410060528),
+        (0.89, 7348, 0.800042935968912),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.80, proportion = 0.71 to 0.89 by 0.01, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, phat = True, continuity_correction = False
-        TestCase(null_proportion=0.80, proportion=proportion, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, phat=True, continuity_correction=False, actual_power=actual_power)
-        for proportion, actual_power, size in [
-            (0.71, 0.800003801, 16161),
-            (0.72, 0.800016319, 3956),
-            (0.73, 0.800021750, 1719),
-            (0.74, 0.800071545, 944),
-            (0.75, 0.800222418, 589),
-            (0.76, 0.800316402, 398),
-            (0.77, 0.801249565, 285),
-            (0.78, 0.801375954, 217),
-            (0.79, 0.800223275, 182),
-            (0.80, 0.802961846, 169),
-            (0.81, 0.800738510, 169),
-            (0.82, 0.802204172, 187),
-            (0.83, 0.801133297, 227),
-            (0.84, 0.801299217, 294),
-            (0.85, 0.800691755, 401),
-            (0.86, 0.800246739, 591),
-            (0.87, 0.800261254, 987),
-            (0.88, 0.800169469, 2073),
-            (0.89, 0.800048313, 7685),
-        ]
+]
+
+case_group_z_phat = [
+    # proportion = 0.71 to 0.89 by 0.01, null_proportion = 0.80, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, method = "z-phat", continuity_correction = False
+    TestCase(proportion=proportion, null_proportion=0.80, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, method="z-phat", continuity_correction=False, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.71, 16161, 0.800003800757050),
+        (0.72, 3956, 0.800016318697791),
+        (0.73, 1719, 0.800021750404768),
+        (0.74, 944, 0.800071544574412),
+        (0.75, 589, 0.800222417640806),
+        (0.76, 398, 0.800316401568403),
+        (0.77, 285, 0.801249564933707),
+        (0.78, 217, 0.801375954276119),
+        (0.79, 182, 0.800223274815251),
+        (0.80, 169, 0.802961846320122),
+        (0.81, 169, 0.800738509804512),
+        (0.82, 187, 0.802204172126832),
+        (0.83, 227, 0.801133296831188),
+        (0.84, 294, 0.801299217214459),
+        (0.85, 401, 0.800691754951146),
+        (0.86, 591, 0.800246739379968),
+        (0.87, 987, 0.800261253764890),
+        (0.88, 2073, 0.800169469068211),
+        (0.89, 7685, 0.800048313460553),
     ]
-    + [
-        # Regular Cases: null_proportion = 0.80, proportion = 0.71 to 0.89 by 0.01, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, phat = True, continuity_correction = True
-        TestCase(null_proportion=0.80, proportion=proportion, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, phat=True, continuity_correction=True, actual_power=actual_power)
-        for proportion, actual_power, size in [
-            (0.71, 0.800007531, 16261),
-            (0.72, 0.800031784, 4006),
-            (0.73, 0.800209910, 1753),
-            (0.74, 0.800138515, 969),
-            (0.75, 0.800331680, 609),
-            (0.76, 0.800809692, 415),
-            (0.77, 0.801196838, 299),
-            (0.78, 0.801771186, 229),
-            (0.79, 0.802231738, 193),
-            (0.80, 0.800073350, 178),
-            (0.81, 0.802924842, 180),
-            (0.82, 0.800353268, 198),
-            (0.83, 0.801135120, 241),
-            (0.84, 0.800710197, 310),
-            (0.85, 0.800923659, 421),
-            (0.86, 0.800414922, 616),
-            (0.87, 0.800237025, 1020),
-            (0.88, 0.800036010, 2122),
-            (0.89, 0.800013673, 7784),
-        ]
+]
+
+case_group_z_phat_cc = [
+    # proportion = 0.71 to 0.89 by 0.01, null_proportion = 0.80, margin_lower = -0.10, margin_upper = 0.10, alpha = 0.025, power = 0.80, method = "z-phat", continuity_correction = True
+    TestCase(proportion=proportion, null_proportion=0.80, margin_lower=-0.10, margin_upper=0.10, size=size, alpha=0.025, power=0.80, method="z-phat", continuity_correction=True, actual_power=actual_power)
+    for proportion, size, actual_power in [
+        (0.71, 16261, 0.800007531462899),
+        (0.72, 4006, 0.800031784019027),
+        (0.73, 1753, 0.800209909579564),
+        (0.74, 969, 0.800138514675414),
+        (0.75, 609, 0.800331680146841),
+        (0.76, 415, 0.800809691940262),
+        (0.77, 299, 0.801196837939170),
+        (0.78, 229, 0.801771186082395),
+        (0.79, 193, 0.802231737618877),
+        (0.80, 178, 0.800073350151615),
+        (0.81, 180, 0.802924842313689),
+        (0.82, 198, 0.800353268485122),
+        (0.83, 241, 0.801135120000960),
+        (0.84, 310, 0.800710197383088),
+        (0.85, 421, 0.800923658669870),
+        (0.86, 616, 0.800414922435674),
+        (0.87, 1020, 0.800237025247695),
+        (0.88, 2122, 0.800036010477757),
+        (0.89, 7784, 0.800013672909686),
     ]
-)
+]
+
+case_group = case_group_z_p0 + case_group_z_p0_cc + case_group_z_phat + case_group_z_phat_cc
 
 
 def test_size_solve_power(case: TestCase) -> None:
     assert round(
         solve_power(
-            null_proportion=case.null_proportion,
             proportion=case.proportion,
+            null_proportion=case.null_proportion,
             margin_lower=case.margin_lower,
             margin_upper=case.margin_upper,
             size=case.size,
             alpha=case.alpha,
-            phat=case.phat,
+            method=case.method,
             continuity_correction=case.continuity_correction,
         ),
-        4,
-    ) == round(case.actual_power, 4)
+        6,
+    ) == round(case.actual_power, 6)
 
 
 def test_solve_size(case: TestCase) -> None:
     assert (
         solve_size(
-            null_proportion=case.null_proportion,
             proportion=case.proportion,
+            null_proportion=case.null_proportion,
             margin_lower=case.margin_lower,
             margin_upper=case.margin_upper,
             alpha=case.alpha,
             power=case.power,
-            phat=case.phat,
+            method=case.method,
             continuity_correction=case.continuity_correction,
         )
         == case.size
     )
-
-
-def test_size_solve_null_proportion(case: TestCase) -> None:
-    assert any(
-        [
-            round(
-                solve_null_proportion(
-                    proportion=case.proportion,
-                    margin_lower=case.margin_lower,
-                    margin_upper=case.margin_upper,
-                    size=case.size,
-                    alpha=case.alpha,
-                    power=case.actual_power,
-                    phat=case.phat,
-                    continuity_correction=case.continuity_correction,
-                    search_direction=search_direction,
-                ),
-                2,
-            )
-            == case.null_proportion
-            for search_direction in ["lower", "upper"]
-        ]
-    )
-
-
-def test_size_solve_proportion(case: TestCase) -> None:
-    assert any(
-        [
-            round(
-                solve_proportion(
-                    null_proportion=case.null_proportion,
-                    margin_lower=case.margin_lower,
-                    margin_upper=case.margin_upper,
-                    size=case.size,
-                    alpha=case.alpha,
-                    power=case.actual_power,
-                    phat=case.phat,
-                    continuity_correction=case.continuity_correction,
-                    search_direction=search_direction,
-                ),
-                2,
-            )
-            == case.proportion
-            for search_direction in ["lower", "upper"]
-        ]
-    )
-
-
-# def test_solve_margin(case: TestCase) -> None:
-#     assert (
-#         round(
-#             solve_margin(
-#                 null_proportion=case.null_proportion,
-#                 proportion=case.proportion,
-#                 size=case.size,
-#                 alternative=case.alternative,
-#                 alpha=case.alpha,
-#                 power=case.actual_power,
-#                 phat=case.phat,
-#                 continuity_correction=case.continuity_correction,
-#             ),
-#             2,
-#         )
-#         == case.margin
-#     )


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified power calculation by removing redundant functions.

- Removed `solve_null_proportion` and `solve_proportion`.

- Updated test cases with refined precision and new method parameter.

- Improved documentation and corrected formula notation.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>equivalence.py</strong><dd><code>Refactor power functions and remove unneeded functions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/single/equivalence.py

<ul><li>Removed <code>_power_p0</code>, <code>_power_p0_cc</code>, <code>_power_phat</code>, <code>_power_phat_cc</code>, and <br><code>_continuity_correction</code>.<br> <li> Replaced with a single <code>_power</code> function that delegates to <code>_raw_power</code>.<br> <li> Removed <code>solve_null_proportion</code> and <code>solve_proportion</code> functions.<br> <li> Changed <code>phat</code> parameter to <code>method</code> and reordered arguments.<br> <li> Updated docstrings and sample size search bounds.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/527/files#diff-192dc4e9326e103d65c51324b245ebb6c6ed331fb41d450f2a05464402f54057">+47/-350</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_equivalence.py</strong><dd><code>Update tests for simplified module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_proportion/test_single/test_equivalence.py

<ul><li>Deleted tests for <code>solve_null_proportion</code> and <code>solve_proportion</code>.<br> <li> Restructured test cases into four groups by method and continuity <br>correction.<br> <li> Updated test data with more precise <code>actual_power</code> values.<br> <li> Changed <code>phat</code> parameter to <code>method</code> in test functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/527/files#diff-6796089203ff51c6fcd6388bc87e46a0b63952af1461bbce02fe24c94c929a6c">+114/-175</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>equivalence.md</strong><dd><code>Improve documentation and formula notation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/algorithms/proportion/single/equivalence.md

<ul><li>Unified terminology and notation (e.g., <code>z_{alpha}</code> instead of <br><code>-z_{1-alpha}</code>).<br> <li> Improved formula layout and added section headings.<br> <li> Removed redundant variance statements and simplified power <br>derivations.<br> <li> Added reference to Chow et al.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/527/files#diff-694b1517aecc96fa82cb988ad2bb9f4977a64a6f048af37c1f3597e73c9fb1ad">+59/-115</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

