### PR TITLE
fix: set missing default values

### DIFF
--- a/src/pystatpower/mean/single/inequality.py
+++ b/src/pystatpower/mean/single/inequality.py
@@ -74,8 +74,8 @@ def solve_power(
     diff: float | None = None,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "greater", "less"],
-    alpha: float,
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
+    alpha: float = 0.05,
     dist: Literal["z", "t"] = "t",
 ) -> float:
     """
@@ -135,8 +135,8 @@ def solve_size(
     null_mean: float | None = None,
     diff: float | None = None,
     std: float,
-    alternative: Literal["two-sided", "greater", "less"],
-    alpha: float,
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
+    alpha: float = 0.05,
     power: float = 0.8,
     dist: Literal["z", "t"] = "t",
 ) -> int:
@@ -201,10 +201,10 @@ def solve_mean(
     null_mean: float,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "greater", "less"],
-    alpha: float,
-    power: float,
-    dist: Literal["z", "t"],
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
+    alpha: float = 0.05,
+    power: float = 0.8,
+    dist: Literal["z", "t"] = "t",
     direction: Literal["greater", "less"] | None = None,
 ) -> float:
     """
@@ -278,8 +278,8 @@ def solve_null_mean(
     mean: float,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "greater", "less"],
-    alpha: float,
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
+    alpha: float = 0.05,
     power: float = 0.8,
     dist: Literal["z", "t"] = "t",
     direction: Literal["greater", "less"] | None = None,
@@ -354,10 +354,10 @@ def solve_diff(
     *,
     std: float,
     size: int,
-    alternative: Literal["two-sided", "greater", "less"],
-    alpha: float,
-    power: float,
-    dist: Literal["z", "t"],
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
+    alpha: float = 0.05,
+    power: float = 0.8,
+    dist: Literal["z", "t"] = "t",
     direction: Literal["greater", "less"] | None = None,
 ) -> float:
     """
@@ -430,10 +430,10 @@ def solve_std(
     null_mean: float | None = None,
     diff: float | None = None,
     size: int,
-    alternative: Literal["two-sided", "greater", "less"],
-    alpha: float,
-    power: float,
-    dist: Literal["z", "t"],
+    alternative: Literal["two-sided", "greater", "less"] = "two-sided",
+    alpha: float = 0.05,
+    power: float = 0.8,
+    dist: Literal["z", "t"] = "t",
 ) -> float:
     """
     Estimate the required standard deviation.

--- a/src/pystatpower/proportion/independent/inequality.py
+++ b/src/pystatpower/proportion/independent/inequality.py
@@ -42,7 +42,7 @@ def solve_power(
     reference_size: int,
     alternative: Literal["two-sided", "one-sided"],
     alpha: float = 0.05,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -99,7 +99,7 @@ def solve_size(
     ratio: float = 1,
     alpha: float = 0.05,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> tuple[int, int]:
     """
@@ -188,7 +188,7 @@ def solve_treatment_proportion(
     alternative: Literal["two-sided", "one-sided"],
     alpha: float = 0.05,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
     direction: Literal["greater", "less"],
 ) -> float:
@@ -263,7 +263,7 @@ def solve_reference_proportion(
     alternative: Literal["two-sided", "one-sided"],
     alpha: float = 0.05,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
     direction: Literal["greater", "less"],
 ) -> float:

--- a/src/pystatpower/proportion/independent/noninferiority.py
+++ b/src/pystatpower/proportion/independent/noninferiority.py
@@ -24,8 +24,8 @@ def solve_power(
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
-    alpha: float = 0.05,
-    method: Literal["z-pooled", "z-unpooled"],
+    alpha: float = 0.025,
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -94,9 +94,9 @@ def solve_size(
     margin: float,
     alternative: Literal["greater", "less"],
     ratio: float = 1,
-    alpha: float = 0.05,
+    alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> tuple[int, int]:
     """
@@ -198,9 +198,9 @@ def solve_treatment_proportion(
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
-    alpha: float = 0.05,
+    alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -308,9 +308,9 @@ def solve_reference_proportion(
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
-    alpha: float = 0.05,
+    alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -418,9 +418,9 @@ def solve_margin(
     treatment_size: int,
     reference_size: int,
     alternative: Literal["greater", "less"],
-    alpha: float = 0.05,
+    alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-pooled", "z-unpooled"],
+    method: Literal["z-pooled", "z-unpooled"] = "z-unpooled",
     continuity_correction: bool = False,
 ) -> float:
     """

--- a/src/pystatpower/proportion/single/equivalence.py
+++ b/src/pystatpower/proportion/single/equivalence.py
@@ -33,7 +33,7 @@ def solve_power(
     margin_upper: float,
     size: int,
     alpha: float = 0.025,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -77,7 +77,7 @@ def solve_size(
     margin_upper: float,
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> int:
     """

--- a/src/pystatpower/proportion/single/noninferiority.py
+++ b/src/pystatpower/proportion/single/noninferiority.py
@@ -40,7 +40,7 @@ def solve_power(
     size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool,
 ) -> float:
     """
@@ -111,7 +111,7 @@ def solve_size(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> int:
     """
@@ -190,7 +190,7 @@ def solve_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -296,7 +296,7 @@ def solve_null_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -391,7 +391,7 @@ def solve_noninferiority_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -474,7 +474,7 @@ def solve_margin(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """

--- a/src/pystatpower/proportion/single/superiority.py
+++ b/src/pystatpower/proportion/single/superiority.py
@@ -40,7 +40,7 @@ def solve_power(
     size: int,
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -111,7 +111,7 @@ def solve_size(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> int:
     """
@@ -189,7 +189,7 @@ def solve_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -298,7 +298,7 @@ def solve_null_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -397,7 +397,7 @@ def solve_superiority_proportion(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """
@@ -479,7 +479,7 @@ def solve_margin(
     alternative: Literal["greater", "less"],
     alpha: float = 0.025,
     power: float = 0.8,
-    method: Literal["z-p0", "z-phat"],
+    method: Literal["z-p0", "z-phat"] = "z-phat",
     continuity_correction: bool = False,
 ) -> float:
     """


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added default values for optional parameters across multiple statistical power functions.

- For mean tests, defaults set for alternative, alpha, power, dist.

- For proportion tests, defaults set for method and alpha (noninferiority alpha now 0.025).

- Improves usability by allowing fewer required arguments.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inequality.py</strong><dd><code>Added defaults to mean power functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/mean/single/inequality.py

<ul><li>Added default values for <code>alternative="two-sided"</code>, <code>alpha=0.05</code>, and in <br>some functions also <code>power=0.8</code>, <code>dist="t"</code>.<br> <li> These parameters were previously required; now they have sensible <br>defaults.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/533/files#diff-8731eff3663401fff7861863df12de3c48859a715ec67a54cc7b0dc1d8799ccd">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inequality.py</strong><dd><code>Added default method for independent proportion tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/independent/inequality.py

<ul><li>Added default <code>method="z-unpooled"</code> to <code>solve_power</code>, <code>solve_size</code>, <br><code>solve_treatment_proportion</code>, <code>solve_reference_proportion</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/533/files#diff-338431c6695ea7ab9268f4540b4ccd919b89d4354dbff9979948f2319d0faaf0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>noninferiority.py</strong><dd><code>Adjusted alpha and added method default for noninferiority</code></dd></summary>
<hr>

src/pystatpower/proportion/independent/noninferiority.py

<ul><li>Changed default <code>alpha</code> from 0.05 to 0.025 for noninferiority tests.<br> <li> Added default <code>method="z-unpooled"</code> across all functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/533/files#diff-023df9647ec412c5a534f3c2f2e407bc57a40191c4a04c78f8bf7127d941e6ca">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>equivalence.py</strong><dd><code>Added method default for single proportion equivalence</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/single/equivalence.py

- Added default `method="z-phat"` to `solve_power` and `solve_size`.


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/533/files#diff-192dc4e9326e103d65c51324b245ebb6c6ed331fb41d450f2a05464402f54057">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>noninferiority.py</strong><dd><code>Added method default for single proportion noninferiority</code></dd></summary>
<hr>

src/pystatpower/proportion/single/noninferiority.py

<ul><li>Added default <code>method="z-phat"</code> to all functions.<br> <li> Note: <code>continuity_correction</code> for <code>solve_power</code> remains required (no <br>default).</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/533/files#diff-0f631e564e15ef88a2e51acf84a7fab4ce67cf0bba5dc33009bf2326f17b5f84">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>superiority.py</strong><dd><code>Added method default for single proportion superiority</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pystatpower/proportion/single/superiority.py

- Added default `method="z-phat"` to all functions.


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/533/files#diff-8a2eeb3029983a36532fe577d9ec0a0a6409b84294119d8b81a1d36dc4ead187">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

