### PR TITLE
docs: fix anchor link names to match section titles

### DIFF
--- a/docs/algorithms/proportion/single/ci.md
+++ b/docs/algorithms/proportion/single/ci.md
@@ -2,7 +2,7 @@
 
 样本率用 $\hat{p}$ 表示，总体率用 $p$ 表示。
 
-## _Simple Asymptotic_ {#normal-approx}
+## _Simple Asymptotic_ {#simple-asymptotic}
 
 样本率 $\hat{p}$ 在大样本时，其分布近似服从正态分布：
 
@@ -61,9 +61,9 @@ $$
     d = \min(U, 1) - \hat{p}
     $$
 
-## _Simple Asymptotic with Continuity Correction_ {#normal-approx-cc}
+## _Simple Asymptotic with Continuity Correction_ {#simple-asymptotic-cc}
 
-在 [渐进正态法](#normal-approx) 的基础上添加校正项 $1/2n$：
+在 [_Simple Asymptotic_](#simple-asymptotic) 的基础上添加校正项 $1/2n$：
 
 $$
 z = \frac{\hat{p} - p \pm \frac{1}{2n}}{\sqrt{\hat{p}(1-\hat{p})/n}} \sim N(0, 1)


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fix anchor link names to match section titles


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.md</strong><dd><code>Fix anchor names and cross-reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/algorithms/proportion/single/ci.md

<ul><li>Changed anchor <code>#normal-approx</code> to <code>#simple-asymptotic</code><br> <li> Changed anchor <code>#normal-approx-cc</code> to <code>#simple-asymptotic-cc</code><br> <li> Updated cross-reference text to use new anchor</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/538/files#diff-d4584adf5299a75f373e7490cb345988d4ee36f13647e4a576431708723b0108">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

