### PR TITLE
chore: remove pre-commit hook `check-docstring-first` and `requirements-txt-fixer`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
-      - id: check-docstring-first
       - id: check-illegal-windows-names
       - id: check-toml
       - id: check-yaml
@@ -24,7 +23,6 @@ repos:
               tests/smoke_test\.py|
               tests/models\.py
           )$
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove check-docstring-first pre-commit hook

- Remove requirements-txt-fixer pre-commit hook


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Remove two pre-commit hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<ul><li>Removed <code>check-docstring-first</code> hook<br> <li> Removed <code>requirements-txt-fixer</code> hook</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/552/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

