### PR TITLE
ci: trigger release workflow on publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*"
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   pypi:


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Change trigger to release published events

- Replace tag push and manual dispatch triggers


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Modify release workflow trigger to release published event</code></dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Modified workflow trigger from push tags and workflow_dispatch to <br>release types [published]<br> <li> Ensures release only runs when a GitHub Release is published</ul>


</details>


  </td>
  <td><a href="https://github.com/Snoopy1866/pystatpower/pull/554/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

